### PR TITLE
Delay parsing trial times

### DIFF
--- a/src/silverlabnwb/header.py
+++ b/src/silverlabnwb/header.py
@@ -224,10 +224,15 @@ class LabViewHeader231(LabViewHeader):
         return self[imaging_section_name]
 
     def _parse_trial_times(self):
-        assert self.trial_times_section in self._raw_fields, \
-            'Trial times not found in header!'
-        for line in self._raw_fields[self.trial_times_section]:
-            words = line.split('\t')
+        # The relevant entries in the raw fields are triples whose first
+        # element is the section header; select them based on that.
+        time_fields = [field
+                       for field in self._raw_fields
+                       if field[0] == self.trial_times_section]
+        assert len(time_fields) > 0, 'Trial times not found in header!'
+        for line in time_fields:
+            # The actual text of the line is the third element in the triple
+            words = line[2].split('\t')
             assert len(words) == 2, 'Too many columns found for trial time'
             # Lines start with a line number (with decimal points) followed by a time
             key, value = int(float(words[0])), float(words[1])

--- a/tests/data/unrecognised line Header.ini
+++ b/tests/data/unrecognised line Header.ini
@@ -14,3 +14,8 @@ Volume Imaging = FALSE
 [FUNCTIONAL IMAGING]
 Functional Mode = "Patch"
 
+[Intertrial FIFO Times]
+0.000000	0.000000
+1.000000	12.345678
+2.000000	12.567890
+3.000000	23.456789


### PR DESCRIPTION
Addressing a TODO comment from earlier version. At the moment we only have tab-separated lines in the Intertrial FIFO Times section (the trigger times indicating beginning and end of trials) so we may not need the extra generalisation this gives. Even so, this moves the parsing of those lines to the relevant place and keeps the original text (without any casting) in the raw fields.

- [x] Move parsing and casting of start/stop times away from generic file reading
- [x] Test on new-format data!
- ~(possibly) Cater for cases when stop-time of the last trial is missing~ done in #35 