### PR TITLE
Ignore default metadata

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ setup(
         'nptdms',
         'numpy',
         'pandas>=0.20',
-        'pyyaml',
+        'ruamel.yaml',
         'tifffile',
     ],
     extras_require={

--- a/src/silverlabnwb/metadata.py
+++ b/src/silverlabnwb/metadata.py
@@ -8,7 +8,7 @@ import os
 
 import appdirs
 import pkg_resources
-import yaml
+import ruamel.yaml as yaml
 
 
 def set_conf_dir(path=appdirs.user_config_dir('SilverLabNwb', 'SilverLab')):

--- a/src/silverlabnwb/metadata.py
+++ b/src/silverlabnwb/metadata.py
@@ -49,11 +49,13 @@ def read_config_file(stream, base_settings=None):
     :param base_settings: if present, a settings dictionary to copy and update
     with the contents of this file.
     """
+    yaml_reader = yaml.YAML()
+    raw_yaml_data = yaml_reader.load(stream)
     if base_settings is None:
         settings = {}
     else:
         settings = base_settings.copy()
-    recursive_dict_update(settings, strip_strings(yaml.safe_load(stream)))
+    recursive_dict_update(settings, strip_strings(raw_yaml_data))
     return settings
 
 
@@ -94,9 +96,9 @@ def strip_strings(settings):
     result = {}
     for k, v in settings.items():
         if isinstance(v, str):
-            result[k] = v.strip()
+            result[k] = v.strip(), 'string_comment'
         elif isinstance(v, collections.Mapping):
-            result[k] = strip_strings(v)
+            result[k] = strip_strings(v), 'mapping_comment'
         else:
-            result[k] = v
+            result[k] = v, 'other_comment'
     return result

--- a/src/silverlabnwb/metadata.py
+++ b/src/silverlabnwb/metadata.py
@@ -108,17 +108,20 @@ class MetadataEntry:
         self.value = value
         self.comment = comment
 
-    def __getattribute__(self, attr):
-        if attr == 'comment':
-            return object.__getattribute__(self, "comment")
-        else:  # for anything else, call __getattribute__ on value directly
-            return getattr(object.__getattribute__(self, "value"), attr)
+    def __getattr__(self, attr):
+        return getattr(self.value, attr)
 
     def __getitem__(self, item):
-        return object.__getattribute__(self, "value")[item]
+        return self.value[item]
 
     def __setitem__(self, key, value):
         object.__getattribute__(self, "value")[key] = value
 
     def __delitem__(self, key):
         del object.__getattribute__(self, "value")[key]
+
+    def __contains__(self, item):
+        return item in self.value
+
+    def __len__(self):
+        return len(self.value)

--- a/src/silverlabnwb/metadata.yaml
+++ b/src/silverlabnwb/metadata.yaml
@@ -17,53 +17,53 @@ people:
 # by a short label that is referenced in the session section at the end of this file.
 experiments:
   template:
-    description: >
-      A general description of the experiment goes here.
-      Can be from Methods.
-      Recommended.
-    data_collection: >
-      Text notes about data collection and analysis. E.g. take from methods.
-      Optional.
-    pharmacology: >
-      Description of drugs used, including how and when they were administered.
-      Anesthesia(s), painkiller(s), etc., plus dosage, concentration, etc.
-      Optional.
-    protocol: >
-      Experimental protocol, if applicable, e.g. include IACUC protocol.
-      Optional.
-    slices: >
-      Description of slices, including information about preparation thickness,
-      orientation, temperature and bath solution.
-      Optional.
-    stimulus: >
-      Notes about stimuli, such as how and where presented. Can be from Methods.
-      Optional.
+    description: #>
+    #  A general description of the experiment goes here.
+    #  Can be from Methods.
+    #  Recommended.
+    data_collection: #>
+    #  Text notes about data collection and analysis. E.g. take from methods.
+    #  Optional.
+    pharmacology: #>
+    #  Description of drugs used, including how and when they were administered.
+    #  Anesthesia(s), painkiller(s), etc., plus dosage, concentration, etc.
+    #  Optional.
+    protocol: #>
+    #  Experimental protocol, if applicable, e.g. include IACUC protocol.
+    #  Optional.
+    slices: #>
+    #  Description of slices, including information about preparation thickness,
+    #  orientation, temperature and bath solution.
+    #  Optional.
+    stimulus: #>
+    #  Notes about stimuli, such as how and where presented. Can be from Methods.
+    #  Optional.
     subject:
       # Information about the animal or person from which the data was measured. Optional.
-      age: Age of subject. Optional.
-      description: >
-        Description of subject and where subject came from (e.g., breeder, if animal).
-        Optional.
-      genotype: "Genetic strain. If absent, assume Wild Type (WT). Optional."
-      sex: Gender of subject. Optional.
-      species: Species of subject. Optional.
-      subject_id: "ID of animal/person used/participating in experiment (lab convention). Optional."
-      weight: >
-        Weight at time of experiment, at time of surgery and at other important times.
-        Optional.
-    surgery: >
-      Narrative description about surgery/surgeries, including date(s) and who performed surgery.
-      Much can be copied from Methods.
-      Optional.
-    virus: >
-      Information about virus(es) used in experiments, including virus ID, source, date made,
-      injection location, volume, etc.
-      Optional.
-    notes: >
-      Notes about the experiment that don't fit elsewhere.
-      Optional.
-    related_publications: >
-      Optional list of related publications, identified by DOI, PMID or URL.
+      age: # Age of subject. Optional.
+      description: #>
+      #  Description of subject and where subject came from (e.g., breeder, if animal).
+      #  Optional.
+      genotype: # "Genetic strain. If absent, assume Wild Type (WT). Optional."
+      sex: # Gender of subject. Optional.
+      species: # Species of subject. Optional.
+      subject_id: # "ID of animal/person used/participating in experiment (lab convention). Optional."
+      weight: #>
+      #  Weight at time of experiment, at time of surgery and at other important times.
+      #  Optional.
+    surgery: #>
+    #  Narrative description about surgery/surgeries, including date(s) and who performed surgery.
+    #  Much can be copied from Methods.
+    #  Optional.
+    virus: #>
+    #  Information about virus(es) used in experiments, including virus ID, source, date made,
+    #  injection location, volume, etc.
+    #  Optional.
+    notes: #>
+    #  Notes about the experiment that don't fit elsewhere.
+    #  Optional.
+    related_publications: #>
+    #  Optional list of related publications, identified by DOI, PMID or URL.
     optophysiology:
       excitation_lambda: NaN # Excitation wavelength
       emission_lambda:

--- a/src/silverlabnwb/metadata.yaml
+++ b/src/silverlabnwb/metadata.yaml
@@ -65,13 +65,12 @@ experiments:
     related_publications: #>
     #  Optional list of related publications, identified by DOI, PMID or URL.
     optophysiology:
-      excitation_lambda: NaN # Excitation wavelength
+      excitation_lambda: .nan # Excitation wavelength
       emission_lambda:
-        green: NaN # Emission wavelength for green channel
-        red: NaN # Emission wavelength for red channel
-      calcium_indicator: Calcium indicator.
-      location: >
-        Anatomy gross description of imaging location, e.g. vermis, visual cortex, depth of recording.
+        green: .nan # Emission wavelength for green channel
+        red: .nan # Emission wavelength for red channel
+      calcium_indicator: Not specified # Calcium indicator.
+      location: Not specified # Anatomy gross description of imaging location, e.g. vermis, visual cortex, depth of recording.
       # We should also have a more detailed 'reference_frame' for each imaging plane, which describes
       # position and reference frame of manifold based on position of first element in manifold.
       # For example, text description of anotomical location or vectors needed to rotate to common

--- a/src/silverlabnwb/metadata_gui.py
+++ b/src/silverlabnwb/metadata_gui.py
@@ -9,7 +9,11 @@ from . import metadata
 
 def wrap_dict(metadata):
     """Convert a metadata dict to use Tk variables to wrap entries."""
-    return {key: (wrap_value(value), comment) for key, (value, comment) in metadata.items()}
+    return {key: wrap_value(value) for key, value in metadata.items()}
+
+
+def wrap_entry(entry):
+    return metadata.MetadataEntry(wrap_value(entry), entry.comment)
 
 
 def wrap_list(metadata):
@@ -45,6 +49,8 @@ def wrap_value(value):
         if hasattr(value, 'strip'):
             value = value.strip()
         wrapped.set(value)
+    elif isinstance(value, metadata.MetadataEntry):
+        wrapped = wrap_entry(value)
     else:
         raise ValueError('Unexpected metadata item {} of type {}'.format(value, type(value)))
     return wrapped
@@ -406,7 +412,10 @@ class MetadataEditor(ttk.Frame):
     def make_expts_part(self, parent, part_name):
         """Make a component frame for the experiment editor."""
         frame = ttk.Frame(parent)
-        self.make_label(frame, part_name)
+        tooltip_text = ''
+        if hasattr(self.template_expt[part_name], "comment"):
+            tooltip_text = self.template_expt[part_name].comment
+        self.make_label(frame, part_name, tooltip_text=tooltip_text)
         if isinstance(self.template_expt[part_name], collections.Mapping):
             # This is actually a related group of fields
             self.expts_boxes[part_name] = boxes = {}

--- a/src/silverlabnwb/metadata_gui.py
+++ b/src/silverlabnwb/metadata_gui.py
@@ -410,7 +410,11 @@ class MetadataEditor(ttk.Frame):
         else:
             textbox = T.Text(frame, width=100, height=5, wrap='word')
             textbox.grid(row=1, column=0, sticky='nesw')
-            textbox.insert('1.0', self.template_expt[part_name])
+            expts_part = self.template_expt[part_name]
+            if expts_part is not None:
+                textbox.insert('1.0', expts_part)
+            else:
+                textbox.insert('1.0', "")
             self.expts_boxes[part_name] = textbox
         frame.pack(side='top', fill='x', expand=True)
 

--- a/src/silverlabnwb/metadata_gui.py
+++ b/src/silverlabnwb/metadata_gui.py
@@ -13,7 +13,7 @@ def wrap_dict(metadata):
 
 
 def wrap_entry(entry):
-    return metadata.MetadataEntry(wrap_value(entry), entry.comment)
+    return metadata.MetadataEntry(wrap_value(entry.value), entry.comment)
 
 
 def wrap_list(metadata):
@@ -26,7 +26,9 @@ def wrap_value(value):
 
     String values will automatically be stripped.
     """
-    if isinstance(value, collections.Mapping):
+    if isinstance(value, metadata.MetadataEntry):
+        wrapped = wrap_entry(value)
+    elif isinstance(value, collections.Mapping):
         wrapped = wrap_dict(value)
     elif isinstance(value, list):
         wrapped = wrap_list(value)
@@ -49,8 +51,6 @@ def wrap_value(value):
         if hasattr(value, 'strip'):
             value = value.strip()
         wrapped.set(value)
-    elif isinstance(value, metadata.MetadataEntry):
-        wrapped = wrap_entry(value)
     else:
         raise ValueError('Unexpected metadata item {} of type {}'.format(value, type(value)))
     return wrapped
@@ -326,7 +326,7 @@ class MetadataEditor(ttk.Frame):
                      'subject', 'surgery', 'virus', 'related_publications', 'notes']:
             self.make_expts_part(frame, part)
         # Show current experiment, if any
-        if self.metadata['experiments']:
+        if len(self.metadata['experiments']) > 0:
             experiment.set(experiment['values'][0])
             self.update_expts_tab(expt_id=experiment.get())
         # Add to tabs
@@ -416,14 +416,14 @@ class MetadataEditor(ttk.Frame):
         if hasattr(self.template_expt[part_name], "comment"):
             tooltip_text = self.template_expt[part_name].comment
         self.make_label(frame, part_name, tooltip_text=tooltip_text)
-        if isinstance(self.template_expt[part_name], collections.Mapping):
+        if isinstance(self.template_expt[part_name].value, collections.Mapping):
             # This is actually a related group of fields
             self.expts_boxes[part_name] = boxes = {}
-            self.make_expts_fields(frame, self.template_expt[part_name], boxes)
+            self.make_expts_fields(frame, self.template_expt[part_name].value, boxes)
         else:
             textbox = T.Text(frame, width=100, height=5, wrap='word')
             textbox.grid(row=1, column=0, sticky='nesw')
-            expts_part = self.template_expt[part_name]
+            expts_part = self.template_expt[part_name].value
             if expts_part is not None:
                 textbox.insert('1.0', expts_part)
             else:

--- a/src/silverlabnwb/metadata_gui.py
+++ b/src/silverlabnwb/metadata_gui.py
@@ -9,7 +9,7 @@ from . import metadata
 
 def wrap_dict(metadata):
     """Convert a metadata dict to use Tk variables to wrap entries."""
-    return {key: wrap_value(value) for key, value in metadata.items()}
+    return {key: (wrap_value(value), comment) for key, (value, comment) in metadata.items()}
 
 
 def wrap_list(metadata):
@@ -395,12 +395,13 @@ class MetadataEditor(ttk.Frame):
                 elif field in expt:
                     del expt[field]
 
-    def make_label(self, parent, name, row=0, sticky='w'):
+    def make_label(self, parent, name, row=0, sticky='w', tooltip_text=""):
         """Make the human-friendly label for a form section."""
         name = name.capitalize().replace('_', ' ') + ':'
         label = ttk.Label(parent, text=name)
         label.grid(row=row, column=0, sticky=sticky)
-        tooltip = Hovertip(label, "dummy tool tip text", hover_delay=1000)  # delay in ms
+        if len(tooltip_text) > 0:
+            Hovertip(label, tooltip_text, hover_delay=1000)  # delay in ms
 
     def make_expts_part(self, parent, part_name):
         """Make a component frame for the experiment editor."""
@@ -452,7 +453,6 @@ class MetadataEditor(ttk.Frame):
             self.expts_boxes[part_name].append(boxes)
             self.make_expts_fields(frame, stim, boxes)
         frame.pack(side='top', fill='x', expand=True)
-
 
 def run_editor():
     '''Run the metadata editor.'''

--- a/src/silverlabnwb/metadata_gui.py
+++ b/src/silverlabnwb/metadata_gui.py
@@ -2,6 +2,7 @@
 import collections
 import tkinter as T
 from tkinter import messagebox, ttk
+from idlelib.tooltip import Hovertip
 
 from . import metadata
 
@@ -397,7 +398,9 @@ class MetadataEditor(ttk.Frame):
     def make_label(self, parent, name, row=0, sticky='w'):
         """Make the human-friendly label for a form section."""
         name = name.capitalize().replace('_', ' ') + ':'
-        ttk.Label(parent, text=name).grid(row=row, column=0, sticky=sticky)
+        label = ttk.Label(parent, text=name)
+        label.grid(row=row, column=0, sticky=sticky)
+        tooltip = Hovertip(label, "dummy tool tip text", hover_delay=1000)  # delay in ms
 
     def make_expts_part(self, parent, part_name):
         """Make a component frame for the experiment editor."""

--- a/src/silverlabnwb/nwb_file.py
+++ b/src/silverlabnwb/nwb_file.py
@@ -191,6 +191,7 @@ class NwbFile():
 
     def add_subject(self, subject_data):
         """Add the valid subject information from YAML config to the NWB file.
+
         Use pynwb default if a subject information entry is None."""
         valid_subject_data = {key: value for key, value in subject_data.items() if value is not None}
         subject = Subject(**valid_subject_data)
@@ -263,10 +264,10 @@ class NwbFile():
         return self.user_metadata
 
     def add_general_info(self, label, value):
-        """Add a general piece of information about the experiment if it is specified."""
-        # We allow optional values to not be specified, in which case they will be None,
-        # and pynwb defaults will be used.
-        #
+        """Add a general piece of information about the experiment if it is specified.
+
+        We allow optional values to not be specified, in which case they will be None,
+        and pynwb defaults will be used."""
         # In the new API version, most labels are now attributes of the NWB file
         # itself (including experiment_description, lab, and others). However,
         # it appears that the file object also supports assignment of arbitrary

--- a/src/silverlabnwb/nwb_file.py
+++ b/src/silverlabnwb/nwb_file.py
@@ -190,8 +190,10 @@ class NwbFile():
         self._write()
 
     def add_subject(self, subject_data):
-        """Add the subject information from YAML config to the NWB file."""
-        subject = Subject(**subject_data)
+        """Add the valid subject information from YAML config to the NWB file.
+        Use pynwb default if a subject information entry is None."""
+        valid_subject_data = {key: value for key, value in subject_data.items() if value is not None}
+        subject = Subject(**valid_subject_data)
         self.add_general_info('subject', subject)
 
     def import_labview_data(self, folder_path, folder_name, speed_data, expt_start_time):
@@ -261,7 +263,10 @@ class NwbFile():
         return self.user_metadata
 
     def add_general_info(self, label, value):
-        """Add a general piece of information about the experiment."""
+        """Add a general piece of information about the experiment if it is specified."""
+        # We allow optional values to not be specified, in which case they will be None,
+        # and pynwb defaults will be used.
+        #
         # In the new API version, most labels are now attributes of the NWB file
         # itself (including experiment_description, lab, and others). However,
         # it appears that the file object also supports assignment of arbitrary
@@ -269,7 +274,8 @@ class NwbFile():
         # that causes a problem is when we set an attribute that is already set,
         # which raises an AttributeError. The error message there is clear
         # enough that I don't think we need to raise a more specific exception.
-        setattr(self.nwb_file, label, value)
+        if value is not None:
+            setattr(self.nwb_file, label, value)
 
     def add_devices_info(self):
         """Populate /general/devices with information about the rig.


### PR DESCRIPTION
Addresses #37 and part of #41. Idea is to comment out the explanations to optional and required metadata parameters in the yaml files, so nwb_file writes pynwb defaults to file, instead of the explanations. Commented out explanations can be read using `ruamel.yaml` and displayed as tool tips in the GUI. Planned steps are:

- [ ] comment out optional explanations, write pynwb defaults
- [ ] comment out required explanations, write 'non-specified' as default
- [ ] switch to `ruamel.yaml`
- [ ] adapt GUI to read explanatory comments and display them as tool tips
- [ ] update signatures

tests currently fail due to changes in signature files. All functionality should have tests, too.

Some things yet to be decided: 
- what do we do with actual comments like TODO that are not tool tips? Do we allow them in metadata.yaml?
- should unspecified numbers also be "not specified." strings or e.g. NaN?