### PR TITLE
Create a file from metadata only

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -72,6 +72,7 @@ setup(
             'subsample_nwb = silverlabnwb.subsample_nwb:run',
             'nwb_sig = silverlabnwb.signature:cli',
             'nwb_sig_convert = silverlabnwb.signature:convert_sig_cli',
+            'metadata2nwb = silverlabnwb.script:import_metadata'
         ],
         'gui_scripts': [
             'nwb_metadata_editor = silverlabnwb.metadata_gui:run_editor'

--- a/src/silverlabnwb/metadata.py
+++ b/src/silverlabnwb/metadata.py
@@ -45,7 +45,7 @@ def read_user_config():
 def read_custom_config(config_file):
     """Read the metadata from a user-provided YAML file."""
     with open(config_file) as config:
-        settings, comments = read_base_config_file(config)
+        settings, _ = read_base_config_file(config)
     return settings
 
 

--- a/src/silverlabnwb/metadata.py
+++ b/src/silverlabnwb/metadata.py
@@ -42,6 +42,13 @@ def read_user_config():
     return settings, comments
 
 
+def read_custom_config(config_file):
+    """Read the metadata from a user-provided YAML file."""
+    with open(config_file) as config:
+        settings, comments = read_base_config_file(config)
+    return settings
+
+
 def read_base_config_file(stream):
     yaml_reader = YAML()
     parsed_yaml_data = yaml_reader.load(stream)

--- a/src/silverlabnwb/nwb_file.py
+++ b/src/silverlabnwb/nwb_file.py
@@ -122,11 +122,15 @@ class NwbFile():
         self.record_metadata(user)
         # For now, assume that the session start time is recorded in the file
         # (normally we would get this from the LabView data).
-        start_time = pd.to_datetime(sessions[user]['start_time'],
-                                    infer_datetime_format=True)
-        localized_start_time = start_time.tz_localize(timezone('Europe/London'))
+        try:
+            start_time = sessions[user]['start_time']
+        except KeyError:
+            raise ValueError("Start time for session not found!")
+        start_time = pd.to_datetime(
+            start_time, infer_datetime_format=True).tz_localize(
+            timezone('Europe/London'))
         nwb_settings = {
-            'session_start_time': localized_start_time.to_pydatetime(),
+            'session_start_time': start_time.to_pydatetime(),
             'identifier': f"{os.path.basename(metadata_file)}; {datetime.now()}",
             'session_description': self.session_description,
         }

--- a/src/silverlabnwb/nwb_file.py
+++ b/src/silverlabnwb/nwb_file.py
@@ -112,12 +112,13 @@ class NwbFile():
         # This includes the description and start time for the session
         self.user_metadata = metadata.read_custom_config(metadata_file)
         sessions = self.user_metadata.get('sessions')
-        assert sessions, "No sessions found in file!"
+        if not sessions:
+            raise ValueError("No sessions found in file!")
         if not user:
-            # If the user is not specified, pick one and warn if there were more
-            user = list(sessions.keys())[0]
+            # Select the user if it's not ambiguous, otherwise fail
             if len(sessions) > 1:
-                self.log(f'Multiple users found. Using entry for {user}.')
+                raise ValueError('Multiple users found in file.')
+            user = list(sessions.keys())[0]
         self.record_metadata(user)
         # For now, assume that the session start time is recorded in the file
         # (normally we would get this from the LabView data).

--- a/src/silverlabnwb/nwb_file.py
+++ b/src/silverlabnwb/nwb_file.py
@@ -131,6 +131,7 @@ class NwbFile():
         }
         self.nwb_file = NWBFile(**nwb_settings)
         self.add_core_metadata()
+        self.add_custom_silverlab_data(include_opto=False)
         self.log('All metadata added')
 
     @property
@@ -732,21 +733,22 @@ class NwbFile():
                                         [len(all_rois), cycles_per_trial]))[::-1]
         self._write_roi_data(all_rois, len(trials), cycles_per_trial, ch_data_shape, folder_path)
 
-    def add_custom_silverlab_data(self):
+    def add_custom_silverlab_data(self, include_opto=True):
         metadata_class = get_class('SilverLabMetaData', 'silverlab_extended_schema')
         silverlab_metadata = metadata_class(name='silverlab_metadata', silverlab_api_version=self.SILVERLAB_NWB_VERSION)
         self.nwb_file.add_lab_meta_data(silverlab_metadata)
-
-        optophysiology_class = get_class('SilverLabOptophysiology', 'silverlab_extended_schema')
-        silverlab_optophysiology = optophysiology_class(name='silverlab_optophysiology',
-                                                        cycle_time=self.custom_silverlab_dict['cycle_time'],
-                                                        cycles_per_trial=self.custom_silverlab_dict[
-                                                            'cycles_per_trial'],
-                                                        frame_size=self.custom_silverlab_dict['frame_size'],
-                                                        imaging_mode=self.custom_silverlab_dict['imaging_mode'],
-                                                        pockels=self.custom_silverlab_dict['zplane_pockels']
-                                                        )
-        self.nwb_file.add_lab_meta_data(silverlab_optophysiology)
+        if include_opto:
+            optophysiology_class = get_class('SilverLabOptophysiology', 'silverlab_extended_schema')
+            silverlab_optophysiology = optophysiology_class(
+                name='silverlab_optophysiology',
+                cycle_time=self.custom_silverlab_dict['cycle_time'],
+                cycles_per_trial=self.custom_silverlab_dict[
+                    'cycles_per_trial'],
+                frame_size=self.custom_silverlab_dict['frame_size'],
+                imaging_mode=self.custom_silverlab_dict['imaging_mode'],
+                pockels=self.custom_silverlab_dict['zplane_pockels']
+            )
+            self.nwb_file.add_lab_meta_data(silverlab_optophysiology)
         self._write()
 
     def _write_roi_data(self, all_rois, num_trials, cycles_per_trial,

--- a/src/silverlabnwb/script.py
+++ b/src/silverlabnwb/script.py
@@ -38,3 +38,20 @@ def import_labview():
             sig_gen.compare_to_sig(args.nwb_path, sig_path)
         else:
             parser.error('No signature file {} found'.format(sig_path))
+
+
+def import_metadata():
+    """Command line script to create a bare-bones NWB file from metadata."""
+    parser = argparse.ArgumentParser(description='Import metadata to NWB.')
+    parser.add_argument('nwb_path',
+                        help='path to the NWB file to write')
+    parser.add_argument('metadata_path',
+                        help='path to a YAML metadata file')
+    parser.add_argument('user',
+                        help='name of a user whose experiment to import (optional)',
+                        nargs='?',
+                        default=None)
+    args = parser.parse_args()
+
+    with NwbFile(args.nwb_path, mode='w') as nwb:
+        nwb.create_from_metadata(args.metadata_path, args.user)

--- a/tests/data/meta_two_users.yaml
+++ b/tests/data/meta_two_users.yaml
@@ -51,11 +51,10 @@ sessions:
 # This section records the last 'session' by each researcher. The definitions are used
 # as defaults for the next session, so multiple similar experiments will require very
 # little modification.
-  A:  # Should match a user id in the 'people' section
+  A:  # This section is missing a start_time, which will cause an error.
     description: A's session description.
     experiment: exp1
-    start_time: 5 May 2020
-  B:   # Should match a user id in the 'people' section
+  B:
     description: B's session description.
     experiment: exp1
     start_time: 10 May 2020

--- a/tests/data/meta_two_users.yaml
+++ b/tests/data/meta_two_users.yaml
@@ -1,0 +1,61 @@
+# This is an example of metadata files that can be used to create a "bare-bones"
+# NWB file, without any experimental data. It is used for testing purposes,
+# but its structure matches the expected one for real usage.
+people:
+  A:
+    name: A-C DC
+    orcid: 0000-0001-2345-6789
+  B:
+    name: B Y-S
+    scopus_id: 1234567890A
+
+
+experiments:
+  exp1:
+    description: Experiment description
+    data_collection: All about the data.
+    pharmacology: Medication.
+    protocol: A protocol.
+    stimulus: Stimulus!
+    subject:
+      age: "2"
+      description: Some more about the subject
+      sex: F
+      subject_id: "42"
+    notes: My notes
+    optophysiology:
+      excitation_lambda: .nan # Excitation wavelength
+      emission_lambda:
+        green: .nan # Emission wavelength for green channel
+        red: .nan # Emission wavelength for red channel
+      calcium_indicator: Not specified # Calcium indicator.
+      location: Not specified # Anatomy gross description of imaging location, e.g. vermis, visual cortex, depth of recording.
+    stimulus_details:  # Required, until it is recorded by Labview!
+      - name: air_puff
+        source: air_puff_device  # Must match a device in the devices section
+        description: "Air puff stimulus"
+        comments: "Delivered 'instantaneously' at the specified times"
+        trial_time_offset: 5.0  # seconds
+
+devices:
+# TODO: Include the make & model of camera, etc.
+  AOL_microscope: "Random access 3d acousto-optic lens two-photon microscope"
+  mouse_wheel_device: "Records mouse speed data"
+  air_puff_device: "Delivers an air puff stimulus to the mouse's whiskers"
+  BodyCam: "90Hz video camera viewing the mouse body"
+  EyeCam: "30Hz video camera viewing the mouse face"
+  WhiskersCam: "300Hz video camera viewing the mouse's whiskers"
+
+
+sessions:
+# This section records the last 'session' by each researcher. The definitions are used
+# as defaults for the next session, so multiple similar experiments will require very
+# little modification.
+  A:  # Should match a user id in the 'people' section
+    description: A's session description.
+    experiment: exp1
+    start_time: 5 May 2020
+  B:   # Should match a user id in the 'people' section
+    description: B's session description.
+    experiment: exp1
+    start_time: 10 May 2020

--- a/tests/data/meta_two_users.yaml
+++ b/tests/data/meta_two_users.yaml
@@ -9,7 +9,6 @@ people:
     name: B Y-S
     scopus_id: 1234567890A
 
-
 experiments:
   exp1:
     description: Experiment description
@@ -24,21 +23,20 @@ experiments:
       subject_id: "42"
     notes: My notes
     optophysiology:
-      excitation_lambda: .nan # Excitation wavelength
+      excitation_lambda: .nan
       emission_lambda:
-        green: .nan # Emission wavelength for green channel
-        red: .nan # Emission wavelength for red channel
-      calcium_indicator: Not specified # Calcium indicator.
-      location: Not specified # Anatomy gross description of imaging location, e.g. vermis, visual cortex, depth of recording.
-    stimulus_details:  # Required, until it is recorded by Labview!
+        green: .nan
+        red: .nan # Leaving a comment to test that it is not stored in the NWB file by accident
+      calcium_indicator: Not specified
+      location: Not specified
+    stimulus_details:
       - name: air_puff
-        source: air_puff_device  # Must match a device in the devices section
+        source: air_puff_device
         description: "Air puff stimulus"
         comments: "Delivered 'instantaneously' at the specified times"
-        trial_time_offset: 5.0  # seconds
+        trial_time_offset: 5.0
 
 devices:
-# TODO: Include the make & model of camera, etc.
   AOL_microscope: "Random access 3d acousto-optic lens two-photon microscope"
   mouse_wheel_device: "Records mouse speed data"
   air_puff_device: "Delivers an air puff stimulus to the mouse's whiskers"
@@ -46,11 +44,7 @@ devices:
   EyeCam: "30Hz video camera viewing the mouse face"
   WhiskersCam: "300Hz video camera viewing the mouse's whiskers"
 
-
 sessions:
-# This section records the last 'session' by each researcher. The definitions are used
-# as defaults for the next session, so multiple similar experiments will require very
-# little modification.
   A:  # This section is missing a start_time, which will cause an error.
     description: A's session description.
     experiment: exp1

--- a/tests/data/metadata_only_B.sig2
+++ b/tests/data/metadata_only_B.sig2
@@ -1,0 +1,27 @@
+Generating signature for metadata_only_B.nwb
+
+/
+	@.specloc: type=Reference val="->/specifications"
+/file_create_date: dtype=ignored shape=ignored val="ignored"
+/general/data_collection: dtype=object shape=() val="All about the data."
+/general/experiment_description: dtype=object shape=() val="Experiment description"
+/general/experimenter: dtype=object shape=(1,) val="[B Y-S]"
+/general/institution: dtype=object shape=() val="University College London"
+/general/lab: dtype=object shape=() val="Silver Lab (http://silverla...0xc56c0ba8"
+/general/notes: dtype=object shape=() val="My notes"
+/general/pharmacology: dtype=object shape=() val="Medication."
+/general/protocol: dtype=object shape=() val="A protocol."
+/general/silverlab_metadata
+	@silverlab_api_version: type=str val="0.2"
+/general/stimulus: dtype=object shape=() val="Stimulus!"
+/general/subject/age: dtype=object shape=() val="2"
+/general/subject/description: dtype=object shape=() val="Some more about the subject"
+/general/subject/sex: dtype=object shape=() val="F"
+/general/subject/subject_id: dtype=object shape=() val="42"
+/identifier: dtype=ignored shape=ignored val="ignored"
+/session_description: dtype=object shape=() val="B's session description."
+/session_start_time: dtype=object shape=() val="2020-05-10T00:00:00+01:00"
+/specifications/silverlab_extended_schema/0.2/namespace: dtype=object shape=() val="{"namespaces":[{"doc":"Exte...0x9056a72"
+/specifications/silverlab_extended_schema/0.2/silverlab.metadata: dtype=object shape=() val="{"groups":[{"doc":"A place ...0xb2e570ae"
+/specifications/silverlab_extended_schema/0.2/silverlab.ophys: dtype=object shape=() val="{"groups":[{"datasets":[{"s...0xf5e48595"
+/timestamps_reference_time: dtype=object shape=() val="2020-05-10T00:00:00+01:00"

--- a/tests/test_metadata_import.py
+++ b/tests/test_metadata_import.py
@@ -23,3 +23,12 @@ def test_user_not_found_fails(tmpdir, ref_data_dir):
             nwb.create_from_metadata(meta_path, user="Mr Faker")
     assert "No session information found for user" in str(exc_info.value)
 
+
+def test_no_start_time_fails(tmpdir, ref_data_dir):
+    fname = "test_metadata_import.nwb"
+    nwb_path = os.path.join(str(tmpdir), fname)
+    meta_path = os.path.join(ref_data_dir, 'meta_two_users.yaml')
+    with pytest.raises(ValueError) as exc_info:
+        with NwbFile(nwb_path, 'w') as nwb:
+            nwb.create_from_metadata(meta_path, user="A")
+    assert "Start time for session not found!" == str(exc_info.value)

--- a/tests/test_metadata_import.py
+++ b/tests/test_metadata_import.py
@@ -1,0 +1,25 @@
+import os
+
+import pytest
+
+from silverlabnwb import NwbFile
+
+
+def test_ambiguous_user_fails(tmpdir, ref_data_dir):
+    fname = "test_metadata_import.nwb"
+    nwb_path = os.path.join(str(tmpdir), fname)
+    meta_path = os.path.join(ref_data_dir, 'meta_two_users.yaml')
+    with pytest.raises(ValueError, match="Multiple users found in file."):
+        with NwbFile(nwb_path, 'w') as nwb:
+            nwb.create_from_metadata(meta_path)
+
+
+def test_user_not_found_fails(tmpdir, ref_data_dir):
+    fname = "test_metadata_import.nwb"
+    nwb_path = os.path.join(str(tmpdir), fname)
+    meta_path = os.path.join(ref_data_dir, 'meta_two_users.yaml')
+    with pytest.raises(ValueError) as exc_info:
+        with NwbFile(nwb_path, 'w') as nwb:
+            nwb.create_from_metadata(meta_path, user="Mr Faker")
+    assert "No session information found for user" in str(exc_info.value)
+

--- a/tests/test_metadata_import.py
+++ b/tests/test_metadata_import.py
@@ -3,6 +3,7 @@ import os
 import pytest
 
 from silverlabnwb import NwbFile
+from silverlabnwb.signature import SignatureGenerator
 
 
 def test_ambiguous_user_fails(tmpdir, ref_data_dir):
@@ -32,3 +33,14 @@ def test_no_start_time_fails(tmpdir, ref_data_dir):
         with NwbFile(nwb_path, 'w') as nwb:
             nwb.create_from_metadata(meta_path, user="A")
     assert "Start time for session not found!" == str(exc_info.value)
+
+
+def test_metadata_import_correct(tmpdir, ref_data_dir):
+    fname = "metadata_only_B.nwb"
+    nwb_path = os.path.join(str(tmpdir), fname)
+    meta_path = os.path.join(ref_data_dir, 'meta_two_users.yaml')
+    sig_path = os.path.join(ref_data_dir, 'metadata_only_B.sig2')
+    with NwbFile(nwb_path, 'w') as nwb:
+        nwb.create_from_metadata(meta_path, user="B")
+    sig_gen = SignatureGenerator()
+    assert sig_gen.compare_to_sig(nwb_path, sig_path)


### PR DESCRIPTION
Will address #41.

- [x] New `create_from_metadata` function on our `NwbFile`
- [x] New CLI entrypoint `metadata2nwb` that calls the above
- [x] Basic tests of the new function
- [ ] Can more functionality be shared between `create_from_metadata` and `import_labview_folder`?

To be merged after #45.