### PR TITLE
Clearer YAML syntax

### DIFF
--- a/src/silverlabnwb/silverlab.ophys.yaml
+++ b/src/silverlabnwb/silverlab.ophys.yaml
@@ -25,9 +25,9 @@ groups:
     shape:
     - null
     - 4
-    doc: "pockels data set, recording calibration data for focusing at different z-planesin\
-      \ four columns: Z offset from focal plane (micrometres), normalised Z,'Pockels'\
-      \ i.e. laser power in %, and z offset for drive motors"
+    doc: "pockels data set, recording calibration data for focusing at different z-planes in
+      four columns: Z offset from focal plane (micrometres), normalised Z,'Pockels'
+      i.e. laser power in %, and z offset for drive motors"
     attributes:
     - name: columns
       dtype: text


### PR DESCRIPTION
I've put in a missing space character between 'z-planes' and 'in', but also switched the string formatting to look more like the other docs - the backslash escaping isn't necessary here.