### PR TITLE
stop wheel from building for python 2

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,3 @@
-[bdist_wheel]
-universal = 1
-
-
 [flake8]
 max-line-length = 140
 exclude = */migrations/*


### PR DESCRIPTION
The reason for our distribution looking like it was being built for python 2 despite us removing support was a setting in `setup.cfg`. See [https://wheel.readthedocs.io/en/stable/quickstart.html](https://wheel.readthedocs.io/en/stable/quickstart.html).

I have tested that this avoids `py2` in the file that `wheel` creates. I assume this means this removes any trace of `Python 2`. `Python 2` was never listed as a supported programming language for the PyPI package, see [https://test.pypi.org/project/silverlabnwb/0.1.0/](https://test.pypi.org/project/silverlabnwb/0.1.0/).