### PR TITLE
Record LabVIEW version in metadata

### DIFF
--- a/src/silverlabnwb/generate_extended_schema.py
+++ b/src/silverlabnwb/generate_extended_schema.py
@@ -32,6 +32,10 @@ def generate_extended_schema():
                                                   doc='For potential future backwards compatibility, '
                                                   'store the \'version\' of this API that created the file.',
                                                   dtype='text')
+    labview_version_attr = NWBAttributeSpec(name='labview_version',
+                                            doc='The version of LabVIEW the data came from',
+                                            dtype='text',
+                                            required=False)
     pockels_column_names_attr = NWBAttributeSpec(name='columns',
                                                  doc='column names for the zplane pockels dataset',
                                                  shape=(4,),
@@ -57,7 +61,7 @@ def generate_extended_schema():
                                             neurodata_type_def='SilverLabOptophysiology',
                                             neurodata_type_inc='LabMetaData')
     silverlab_metadata_specs = NWBGroupSpec(doc='A place to store Silver lab specific metadata',
-                                            attributes=[silverlab_api_version_attr],
+                                            attributes=[silverlab_api_version_attr, labview_version_attr],
                                             neurodata_type_def='SilverLabMetaData',
                                             neurodata_type_inc='LabMetaData',
                                             )

--- a/src/silverlabnwb/generate_extended_schema.py
+++ b/src/silverlabnwb/generate_extended_schema.py
@@ -6,7 +6,7 @@ def generate_extended_schema():
     ns_builder = NWBNamespaceBuilder('Extensions for acousto-optic lens data',
                                      'silverlab_extended_schema',
                                      'Silver lab data extension to NWB format for acousto-optic lens experiments',
-                                     version='0.3')
+                                     version='0.4')
     ns_builder.include_type('LabMetaData', namespace='core')
     ns_builder.include_type('TwoPhotonSeries', namespace='core')
 

--- a/src/silverlabnwb/nwb_file.py
+++ b/src/silverlabnwb/nwb_file.py
@@ -755,7 +755,14 @@ class NwbFile():
 
     def add_custom_silverlab_data(self, include_opto=True):
         metadata_class = get_class('SilverLabMetaData', 'silverlab_extended_schema')
-        silverlab_metadata = metadata_class(name='silverlab_metadata', silverlab_api_version=self.SILVERLAB_NWB_VERSION)
+        custom_metadata = {
+            'name': 'silverlab_metadata',
+            'silverlab_api_version': self.SILVERLAB_NWB_VERSION
+        }
+        # If creating from metadata only, we don't have any LabVIEW data
+        if self.labview_version:
+            custom_metadata['labview_version'] = self.labview_version.value
+        silverlab_metadata = metadata_class(**custom_metadata)
         self.nwb_file.add_lab_meta_data(silverlab_metadata)
         if include_opto:
             optophysiology_class = get_class('SilverLabOptophysiology', 'silverlab_extended_schema')

--- a/src/silverlabnwb/signature.py
+++ b/src/silverlabnwb/signature.py
@@ -42,6 +42,7 @@ class SignatureGenerator:
             '/identifier',
             '/specifications/core/*',
             '/specifications/hdmf-common/*',
+            '/specifications/silverlab_extended_schema/*',
         ]]
         self._ignore_attributes = []
         for path, attr in [

--- a/src/silverlabnwb/silverlab.metadata.yaml
+++ b/src/silverlabnwb/silverlab.metadata.yaml
@@ -7,3 +7,7 @@ groups:
     dtype: text
     doc: For potential future backwards compatibility, store the 'version' of this
       API that created the file.
+  - name: labview_version
+    dtype: text
+    doc: The version of LabVIEW the data came from
+    required: false

--- a/src/silverlabnwb/silverlab.namespace.yaml
+++ b/src/silverlabnwb/silverlab.namespace.yaml
@@ -10,4 +10,4 @@ namespaces:
   - source: silverlab.ophys.yaml
   - source: silverlab.metadata.yaml
   - source: silverlab.roi.yaml
-  version: '0.3'
+  version: '0.4'

--- a/tests/data/161215_15_34_21.sig2
+++ b/tests/data/161215_15_34_21.sig2
@@ -24,6 +24,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_001_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_001_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_001_Green/imaging_plane -> /general/optophysiology/Zstack0027_green
+/acquisition/ROI_001_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x159a045b"
 /acquisition/ROI_001_Green/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_001_Red
@@ -39,6 +40,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_001_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_001_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_001_Red/imaging_plane -> /general/optophysiology/Zstack0027_red
+/acquisition/ROI_001_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x159a045b"
 /acquisition/ROI_001_Red/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_002_Green
@@ -54,6 +56,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_002_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_002_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_002_Green/imaging_plane -> /general/optophysiology/Zstack0027_green
+/acquisition/ROI_002_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x115d038b"
 /acquisition/ROI_002_Green/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_002_Red
@@ -69,6 +72,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_002_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_002_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_002_Red/imaging_plane -> /general/optophysiology/Zstack0027_red
+/acquisition/ROI_002_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x115d038b"
 /acquisition/ROI_002_Red/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_003_Green
@@ -84,6 +88,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_003_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_003_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_003_Green/imaging_plane -> /general/optophysiology/Zstack0029_green
+/acquisition/ROI_003_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x181f04ba"
 /acquisition/ROI_003_Green/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_003_Red
@@ -99,6 +104,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_003_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_003_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_003_Red/imaging_plane -> /general/optophysiology/Zstack0029_red
+/acquisition/ROI_003_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x181f04ba"
 /acquisition/ROI_003_Red/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_004_Green
@@ -114,6 +120,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_004_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_004_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_004_Green/imaging_plane -> /general/optophysiology/Zstack0029_green
+/acquisition/ROI_004_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xce802eb"
 /acquisition/ROI_004_Green/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_004_Red
@@ -129,6 +136,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_004_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_004_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_004_Red/imaging_plane -> /general/optophysiology/Zstack0029_red
+/acquisition/ROI_004_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xce802eb"
 /acquisition/ROI_004_Red/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_005_Green
@@ -144,6 +152,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_005_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_005_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_005_Green/imaging_plane -> /general/optophysiology/Zstack0029_green
+/acquisition/ROI_005_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xfa5031a"
 /acquisition/ROI_005_Green/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_005_Red
@@ -159,6 +168,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_005_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_005_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_005_Red/imaging_plane -> /general/optophysiology/Zstack0029_red
+/acquisition/ROI_005_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xfa5031a"
 /acquisition/ROI_005_Red/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_006_Green
@@ -174,6 +184,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_006_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_006_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_006_Green/imaging_plane -> /general/optophysiology/Zstack0029_green
+/acquisition/ROI_006_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x11630349"
 /acquisition/ROI_006_Green/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_006_Red
@@ -189,6 +200,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_006_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_006_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_006_Red/imaging_plane -> /general/optophysiology/Zstack0029_red
+/acquisition/ROI_006_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x11630349"
 /acquisition/ROI_006_Red/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_007_Green
@@ -204,6 +216,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_007_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_007_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_007_Green/imaging_plane -> /general/optophysiology/Zstack0029_green
+/acquisition/ROI_007_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x8f501fc"
 /acquisition/ROI_007_Green/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_007_Red
@@ -219,6 +232,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_007_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_007_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_007_Red/imaging_plane -> /general/optophysiology/Zstack0029_red
+/acquisition/ROI_007_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x8f501fc"
 /acquisition/ROI_007_Red/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_008_Green
@@ -234,6 +248,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_008_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_008_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_008_Green/imaging_plane -> /general/optophysiology/Zstack0030_green
+/acquisition/ROI_008_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x16520492"
 /acquisition/ROI_008_Green/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_008_Red
@@ -249,6 +264,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_008_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_008_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_008_Red/imaging_plane -> /general/optophysiology/Zstack0030_red
+/acquisition/ROI_008_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x16520492"
 /acquisition/ROI_008_Red/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_009_Green
@@ -264,6 +280,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_009_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_009_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_009_Green/imaging_plane -> /general/optophysiology/Zstack0030_green
+/acquisition/ROI_009_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x12b5042a"
 /acquisition/ROI_009_Green/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_009_Red
@@ -279,6 +296,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_009_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_009_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_009_Red/imaging_plane -> /general/optophysiology/Zstack0030_red
+/acquisition/ROI_009_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x12b5042a"
 /acquisition/ROI_009_Red/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_010_Green
@@ -294,6 +312,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_010_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_010_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_010_Green/imaging_plane -> /general/optophysiology/Zstack0030_green
+/acquisition/ROI_010_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x171104c1"
 /acquisition/ROI_010_Green/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_010_Red
@@ -309,6 +328,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_010_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_010_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_010_Red/imaging_plane -> /general/optophysiology/Zstack0030_red
+/acquisition/ROI_010_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x171104c1"
 /acquisition/ROI_010_Red/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_011_Green
@@ -324,6 +344,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_011_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_011_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_011_Green/imaging_plane -> /general/optophysiology/Zstack0033_green
+/acquisition/ROI_011_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x1076035a"
 /acquisition/ROI_011_Green/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_011_Red
@@ -339,6 +360,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_011_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_011_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_011_Red/imaging_plane -> /general/optophysiology/Zstack0033_red
+/acquisition/ROI_011_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x1076035a"
 /acquisition/ROI_011_Red/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_012_Green
@@ -354,6 +376,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_012_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_012_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_012_Green/imaging_plane -> /general/optophysiology/Zstack0033_green
+/acquisition/ROI_012_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xdd802f2"
 /acquisition/ROI_012_Green/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_012_Red
@@ -369,6 +392,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_012_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_012_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_012_Red/imaging_plane -> /general/optophysiology/Zstack0033_red
+/acquisition/ROI_012_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xdd802f2"
 /acquisition/ROI_012_Red/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_013_Green
@@ -384,6 +408,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_013_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_013_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_013_Green/imaging_plane -> /general/optophysiology/Zstack0033_green
+/acquisition/ROI_013_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xa3b028a"
 /acquisition/ROI_013_Green/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_013_Red
@@ -399,6 +424,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_013_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_013_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_013_Red/imaging_plane -> /general/optophysiology/Zstack0033_red
+/acquisition/ROI_013_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xa3b028a"
 /acquisition/ROI_013_Red/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_014_Green
@@ -414,6 +440,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_014_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_014_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_014_Green/imaging_plane -> /general/optophysiology/Zstack0032_green
+/acquisition/ROI_014_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xe9f0322"
 /acquisition/ROI_014_Green/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_014_Red
@@ -429,6 +456,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_014_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_014_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_014_Red/imaging_plane -> /general/optophysiology/Zstack0032_red
+/acquisition/ROI_014_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xe9f0322"
 /acquisition/ROI_014_Red/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_015_Green
@@ -444,6 +472,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_015_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_015_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_015_Green/imaging_plane -> /general/optophysiology/Zstack0032_green
+/acquisition/ROI_015_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x13fa03b9"
 /acquisition/ROI_015_Green/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_015_Red
@@ -459,6 +488,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_015_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_015_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_015_Red/imaging_plane -> /general/optophysiology/Zstack0032_red
+/acquisition/ROI_015_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x13fa03b9"
 /acquisition/ROI_015_Red/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_016_Green
@@ -474,6 +504,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_016_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_016_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_016_Green/imaging_plane -> /general/optophysiology/Zstack0032_green
+/acquisition/ROI_016_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x105d0351"
 /acquisition/ROI_016_Green/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_016_Red
@@ -489,6 +520,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_016_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_016_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_016_Red/imaging_plane -> /general/optophysiology/Zstack0032_red
+/acquisition/ROI_016_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x105d0351"
 /acquisition/ROI_016_Red/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_017_Green
@@ -504,6 +536,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_017_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_017_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_017_Green/imaging_plane -> /general/optophysiology/Zstack0033_green
+/acquisition/ROI_017_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x14b903e8"
 /acquisition/ROI_017_Green/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_017_Red
@@ -519,6 +552,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_017_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_017_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_017_Red/imaging_plane -> /general/optophysiology/Zstack0033_red
+/acquisition/ROI_017_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x14b903e8"
 /acquisition/ROI_017_Red/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_018_Green
@@ -534,6 +568,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_018_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_018_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_018_Green/imaging_plane -> /general/optophysiology/Zstack0033_green
+/acquisition/ROI_018_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x121b0380"
 /acquisition/ROI_018_Green/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_018_Red
@@ -549,6 +584,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_018_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_018_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_018_Red/imaging_plane -> /general/optophysiology/Zstack0033_red
+/acquisition/ROI_018_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x121b0380"
 /acquisition/ROI_018_Red/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_019_Green
@@ -564,6 +600,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_019_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_019_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_019_Green/imaging_plane -> /general/optophysiology/Zstack0033_green
+/acquisition/ROI_019_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x16770417"
 /acquisition/ROI_019_Green/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_019_Red
@@ -579,6 +616,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_019_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_019_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_019_Red/imaging_plane -> /general/optophysiology/Zstack0033_red
+/acquisition/ROI_019_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x16770417"
 /acquisition/ROI_019_Red/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_020_Green
@@ -594,6 +632,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_020_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_020_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_020_Green/imaging_plane -> /general/optophysiology/Zstack0033_green
+/acquisition/ROI_020_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xbe002b0"
 /acquisition/ROI_020_Green/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_020_Red
@@ -609,6 +648,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_020_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_020_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_020_Red/imaging_plane -> /general/optophysiology/Zstack0033_red
+/acquisition/ROI_020_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xbe002b0"
 /acquisition/ROI_020_Red/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_021_Green
@@ -624,6 +664,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_021_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_021_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_021_Green/imaging_plane -> /general/optophysiology/Zstack0033_green
+/acquisition/ROI_021_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x16370446"
 /acquisition/ROI_021_Green/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_021_Red
@@ -639,6 +680,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_021_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_021_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_021_Red/imaging_plane -> /general/optophysiology/Zstack0033_red
+/acquisition/ROI_021_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x16370446"
 /acquisition/ROI_021_Red/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_022_Green
@@ -654,6 +696,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_022_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_022_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_022_Green/imaging_plane -> /general/optophysiology/Zstack0033_green
+/acquisition/ROI_022_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xd9e02df"
 /acquisition/ROI_022_Green/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_022_Red
@@ -669,6 +712,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_022_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_022_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_022_Red/imaging_plane -> /general/optophysiology/Zstack0033_red
+/acquisition/ROI_022_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xd9e02df"
 /acquisition/ROI_022_Red/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_023_Green
@@ -684,6 +728,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_023_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_023_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_023_Green/imaging_plane -> /general/optophysiology/Zstack0033_green
+/acquisition/ROI_023_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x15000476"
 /acquisition/ROI_023_Green/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_023_Red
@@ -699,6 +744,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_023_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_023_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_023_Red/imaging_plane -> /general/optophysiology/Zstack0033_red
+/acquisition/ROI_023_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x15000476"
 /acquisition/ROI_023_Red/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_024_Green
@@ -714,6 +760,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_024_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_024_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_024_Green/imaging_plane -> /general/optophysiology/Zstack0033_green
+/acquisition/ROI_024_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x175e050d"
 /acquisition/ROI_024_Green/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_024_Red
@@ -729,6 +776,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_024_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_024_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_024_Red/imaging_plane -> /general/optophysiology/Zstack0033_red
+/acquisition/ROI_024_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x175e050d"
 /acquisition/ROI_024_Red/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_025_Green
@@ -744,6 +792,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_025_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_025_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_025_Green/imaging_plane -> /general/optophysiology/Zstack0033_green
+/acquisition/ROI_025_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x13480399"
 /acquisition/ROI_025_Green/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_025_Red
@@ -759,6 +808,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_025_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_025_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_025_Red/imaging_plane -> /general/optophysiology/Zstack0033_red
+/acquisition/ROI_025_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x13480399"
 /acquisition/ROI_025_Red/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_026_Green
@@ -774,6 +824,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_026_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_026_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_026_Green/imaging_plane -> /general/optophysiology/Zstack0034_green
+/acquisition/ROI_026_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x127d03e5"
 /acquisition/ROI_026_Green/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_026_Red
@@ -789,6 +840,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_026_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_026_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_026_Red/imaging_plane -> /general/optophysiology/Zstack0034_red
+/acquisition/ROI_026_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x127d03e5"
 /acquisition/ROI_026_Red/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_027_Green
@@ -804,6 +856,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_027_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_027_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_027_Green/imaging_plane -> /general/optophysiology/Zstack0034_green
+/acquisition/ROI_027_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xfab0331"
 /acquisition/ROI_027_Green/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_027_Red
@@ -819,6 +872,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_027_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_027_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_027_Red/imaging_plane -> /general/optophysiology/Zstack0034_red
+/acquisition/ROI_027_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xfab0331"
 /acquisition/ROI_027_Red/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_028_Green
@@ -834,6 +888,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_028_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_028_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_028_Green/imaging_plane -> /general/optophysiology/Zstack0034_green
+/acquisition/ROI_028_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xfdf037d"
 /acquisition/ROI_028_Green/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_028_Red
@@ -849,6 +904,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_028_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_028_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_028_Red/imaging_plane -> /general/optophysiology/Zstack0034_red
+/acquisition/ROI_028_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xfdf037d"
 /acquisition/ROI_028_Red/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_029_Green
@@ -864,6 +920,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_029_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_029_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_029_Green/imaging_plane -> /general/optophysiology/Zstack0032_green
+/acquisition/ROI_029_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x131003c9"
 /acquisition/ROI_029_Green/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_029_Red
@@ -879,6 +936,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_029_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_029_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_029_Red/imaging_plane -> /general/optophysiology/Zstack0032_red
+/acquisition/ROI_029_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x131003c9"
 /acquisition/ROI_029_Red/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_030_Green
@@ -894,6 +952,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_030_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_030_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_030_Green/imaging_plane -> /general/optophysiology/Zstack0032_green
+/acquisition/ROI_030_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x7460216"
 /acquisition/ROI_030_Green/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_030_Red
@@ -909,6 +968,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_030_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_030_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_030_Red/imaging_plane -> /general/optophysiology/Zstack0032_red
+/acquisition/ROI_030_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x7460216"
 /acquisition/ROI_030_Red/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_031_Green
@@ -924,6 +984,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_031_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_031_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_031_Green/imaging_plane -> /general/optophysiology/Zstack0030_green
+/acquisition/ROI_031_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xf730361"
 /acquisition/ROI_031_Green/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_031_Red
@@ -939,6 +1000,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_031_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_031_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_031_Red/imaging_plane -> /general/optophysiology/Zstack0030_red
+/acquisition/ROI_031_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xf730361"
 /acquisition/ROI_031_Red/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_032_Green
@@ -954,6 +1016,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_032_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_032_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_032_Green/imaging_plane -> /general/optophysiology/Zstack0034_green
+/acquisition/ROI_032_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x119d03ac"
 /acquisition/ROI_032_Green/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_032_Red
@@ -969,6 +1032,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_032_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_032_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_032_Red/imaging_plane -> /general/optophysiology/Zstack0034_red
+/acquisition/ROI_032_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x119d03ac"
 /acquisition/ROI_032_Red/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_033_Green
@@ -984,6 +1048,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_033_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_033_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_033_Green/imaging_plane -> /general/optophysiology/Zstack0034_green
+/acquisition/ROI_033_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xed302f9"
 /acquisition/ROI_033_Green/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_033_Red
@@ -999,6 +1064,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_033_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_033_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_033_Red/imaging_plane -> /general/optophysiology/Zstack0034_red
+/acquisition/ROI_033_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xed302f9"
 /acquisition/ROI_033_Red/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_034_Green
@@ -1014,6 +1080,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_034_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_034_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_034_Green/imaging_plane -> /general/optophysiology/Zstack0034_green
+/acquisition/ROI_034_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x15f90443"
 /acquisition/ROI_034_Green/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_034_Red
@@ -1029,6 +1096,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_034_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_034_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_034_Red/imaging_plane -> /general/optophysiology/Zstack0034_red
+/acquisition/ROI_034_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x15f90443"
 /acquisition/ROI_034_Red/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_035_Green
@@ -1044,6 +1112,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_035_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_035_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_035_Green/imaging_plane -> /general/optophysiology/Zstack0034_green
+/acquisition/ROI_035_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x11310390"
 /acquisition/ROI_035_Green/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_035_Red
@@ -1059,6 +1128,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_035_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_035_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_035_Red/imaging_plane -> /general/optophysiology/Zstack0034_red
+/acquisition/ROI_035_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x11310390"
 /acquisition/ROI_035_Red/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_036_Green
@@ -1074,6 +1144,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_036_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_036_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_036_Green/imaging_plane -> /general/optophysiology/Zstack0034_green
+/acquisition/ROI_036_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xd6002dc"
 /acquisition/ROI_036_Green/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_036_Red
@@ -1089,6 +1160,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_036_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_036_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_036_Red/imaging_plane -> /general/optophysiology/Zstack0034_red
+/acquisition/ROI_036_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xd6002dc"
 /acquisition/ROI_036_Red/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_037_Green
@@ -1104,6 +1176,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_037_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_037_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_037_Green/imaging_plane -> /general/optophysiology/Zstack0034_green
+/acquisition/ROI_037_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x158d0427"
 /acquisition/ROI_037_Green/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_037_Red
@@ -1119,6 +1192,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_037_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_037_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_037_Red/imaging_plane -> /general/optophysiology/Zstack0034_red
+/acquisition/ROI_037_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x158d0427"
 /acquisition/ROI_037_Red/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_038_Green
@@ -1134,6 +1208,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_038_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_038_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_038_Green/imaging_plane -> /general/optophysiology/Zstack0035_green
+/acquisition/ROI_038_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x17bf0473"
 /acquisition/ROI_038_Green/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_038_Red
@@ -1149,6 +1224,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_038_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_038_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_038_Red/imaging_plane -> /general/optophysiology/Zstack0035_red
+/acquisition/ROI_038_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x17bf0473"
 /acquisition/ROI_038_Red/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_039_Green
@@ -1164,6 +1240,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_039_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_039_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_039_Green/imaging_plane -> /general/optophysiology/Zstack0035_green
+/acquisition/ROI_039_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xbf502c0"
 /acquisition/ROI_039_Green/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_039_Red
@@ -1179,6 +1256,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_039_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_039_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_039_Red/imaging_plane -> /general/optophysiology/Zstack0035_red
+/acquisition/ROI_039_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xbf502c0"
 /acquisition/ROI_039_Red/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_040_Green
@@ -1194,6 +1272,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_040_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_040_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_040_Green/imaging_plane -> /general/optophysiology/Zstack0035_green
+/acquisition/ROI_040_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x1422040b"
 /acquisition/ROI_040_Green/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_040_Red
@@ -1209,6 +1288,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_040_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_040_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_040_Red/imaging_plane -> /general/optophysiology/Zstack0035_red
+/acquisition/ROI_040_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x1422040b"
 /acquisition/ROI_040_Red/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_041_Green
@@ -1224,6 +1304,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_041_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_041_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_041_Green/imaging_plane -> /general/optophysiology/Zstack0035_green
+/acquisition/ROI_041_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x164c0456"
 /acquisition/ROI_041_Green/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_041_Red
@@ -1239,6 +1320,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_041_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_041_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_041_Red/imaging_plane -> /general/optophysiology/Zstack0035_red
+/acquisition/ROI_041_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x164c0456"
 /acquisition/ROI_041_Red/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_042_Green
@@ -1254,6 +1336,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_042_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_042_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_042_Green/imaging_plane -> /general/optophysiology/Zstack0035_green
+/acquisition/ROI_042_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x187e04a2"
 /acquisition/ROI_042_Green/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_042_Red
@@ -1269,6 +1352,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_042_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_042_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_042_Red/imaging_plane -> /general/optophysiology/Zstack0035_red
+/acquisition/ROI_042_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x187e04a2"
 /acquisition/ROI_042_Red/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_043_Green
@@ -1284,6 +1368,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_043_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_043_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_043_Green/imaging_plane -> /general/optophysiology/Zstack0035_green
+/acquisition/ROI_043_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x12af03ee"
 /acquisition/ROI_043_Green/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_043_Red
@@ -1299,6 +1384,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_043_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_043_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_043_Red/imaging_plane -> /general/optophysiology/Zstack0035_red
+/acquisition/ROI_043_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x12af03ee"
 /acquisition/ROI_043_Red/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_044_Green
@@ -1314,6 +1400,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_044_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_044_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_044_Green/imaging_plane -> /general/optophysiology/Zstack0035_green
+/acquisition/ROI_044_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xee6033b"
 /acquisition/ROI_044_Green/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_044_Red
@@ -1329,6 +1416,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_044_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_044_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_044_Red/imaging_plane -> /general/optophysiology/Zstack0035_red
+/acquisition/ROI_044_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xee6033b"
 /acquisition/ROI_044_Red/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_045_Green
@@ -1344,6 +1432,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_045_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_045_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_045_Green/imaging_plane -> /general/optophysiology/Zstack0034_green
+/acquisition/ROI_045_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x10110386"
 /acquisition/ROI_045_Green/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_045_Red
@@ -1359,6 +1448,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_045_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_045_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_045_Red/imaging_plane -> /general/optophysiology/Zstack0034_red
+/acquisition/ROI_045_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x10110386"
 /acquisition/ROI_045_Red/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_046_Green
@@ -1374,6 +1464,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_046_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_046_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_046_Green/imaging_plane -> /general/optophysiology/Zstack0034_green
+/acquisition/ROI_046_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x134203d2"
 /acquisition/ROI_046_Green/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_046_Red
@@ -1389,6 +1480,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_046_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_046_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_046_Red/imaging_plane -> /general/optophysiology/Zstack0034_red
+/acquisition/ROI_046_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x134203d2"
 /acquisition/ROI_046_Red/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_047_Green
@@ -1404,6 +1496,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_047_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_047_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_047_Green/imaging_plane -> /general/optophysiology/Zstack0034_green
+/acquisition/ROI_047_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xd7b031f"
 /acquisition/ROI_047_Green/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_047_Red
@@ -1419,6 +1512,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_047_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_047_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_047_Red/imaging_plane -> /general/optophysiology/Zstack0034_red
+/acquisition/ROI_047_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xd7b031f"
 /acquisition/ROI_047_Red/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_048_Green
@@ -1434,6 +1528,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_048_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_048_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_048_Green/imaging_plane -> /general/optophysiology/Zstack0034_green
+/acquisition/ROI_048_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xfa5036a"
 /acquisition/ROI_048_Green/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_048_Red
@@ -1449,6 +1544,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_048_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_048_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_048_Red/imaging_plane -> /general/optophysiology/Zstack0034_red
+/acquisition/ROI_048_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xfa5036a"
 /acquisition/ROI_048_Red/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_049_Green
@@ -1464,6 +1560,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_049_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_049_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_049_Green/imaging_plane -> /general/optophysiology/Zstack0034_green
+/acquisition/ROI_049_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x11d703b6"
 /acquisition/ROI_049_Green/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_049_Red
@@ -1479,6 +1576,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_049_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_049_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_049_Red/imaging_plane -> /general/optophysiology/Zstack0034_red
+/acquisition/ROI_049_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x11d703b6"
 /acquisition/ROI_049_Red/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_050_Green
@@ -1494,6 +1592,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_050_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_050_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_050_Green/imaging_plane -> /general/optophysiology/Zstack0034_green
+/acquisition/ROI_050_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xf050302"
 /acquisition/ROI_050_Green/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_050_Red
@@ -1509,6 +1608,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_050_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_050_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_050_Red/imaging_plane -> /general/optophysiology/Zstack0034_red
+/acquisition/ROI_050_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xf050302"
 /acquisition/ROI_050_Red/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_051_Green
@@ -1524,6 +1624,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_051_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_051_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_051_Green/imaging_plane -> /general/optophysiology/Zstack0033_green
+/acquisition/ROI_051_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x1633044d"
 /acquisition/ROI_051_Green/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_051_Red
@@ -1539,6 +1640,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_051_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_051_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_051_Red/imaging_plane -> /general/optophysiology/Zstack0033_red
+/acquisition/ROI_051_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x1633044d"
 /acquisition/ROI_051_Red/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_052_Green
@@ -1554,6 +1656,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_052_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_052_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_052_Green/imaging_plane -> /general/optophysiology/Zstack0033_green
+/acquisition/ROI_052_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xd66029a"
 /acquisition/ROI_052_Green/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_052_Red
@@ -1569,6 +1672,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_052_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_052_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_052_Red/imaging_plane -> /general/optophysiology/Zstack0033_red
+/acquisition/ROI_052_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xd66029a"
 /acquisition/ROI_052_Red/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_053_Green
@@ -1584,6 +1688,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_053_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_053_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_053_Green/imaging_plane -> /general/optophysiology/Zstack0033_green
+/acquisition/ROI_053_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xd9a02e6"
 /acquisition/ROI_053_Green/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_053_Red
@@ -1599,6 +1704,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_053_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_053_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_053_Red/imaging_plane -> /general/optophysiology/Zstack0033_red
+/acquisition/ROI_053_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xd9a02e6"
 /acquisition/ROI_053_Red/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_054_Green
@@ -1614,6 +1720,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_054_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_054_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_054_Green/imaging_plane -> /general/optophysiology/Zstack0033_green
+/acquisition/ROI_054_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x14c00430"
 /acquisition/ROI_054_Green/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_054_Red
@@ -1629,6 +1736,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_054_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_054_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_054_Red/imaging_plane -> /general/optophysiology/Zstack0033_red
+/acquisition/ROI_054_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x14c00430"
 /acquisition/ROI_054_Red/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_055_Green
@@ -1644,6 +1752,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_055_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_055_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_055_Green/imaging_plane -> /general/optophysiology/Zstack0033_green
+/acquisition/ROI_055_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x17f1047c"
 /acquisition/ROI_055_Green/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_055_Red
@@ -1659,6 +1768,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_055_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_055_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_055_Red/imaging_plane -> /general/optophysiology/Zstack0033_red
+/acquisition/ROI_055_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x17f1047c"
 /acquisition/ROI_055_Red/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_056_Green
@@ -1674,6 +1784,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_056_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_056_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_056_Green/imaging_plane -> /general/optophysiology/Zstack0033_green
+/acquisition/ROI_056_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x112b03c9"
 /acquisition/ROI_056_Green/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_056_Red
@@ -1689,6 +1800,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_056_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_056_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_056_Red/imaging_plane -> /general/optophysiology/Zstack0033_red
+/acquisition/ROI_056_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x112b03c9"
 /acquisition/ROI_056_Red/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_057_Green
@@ -1704,6 +1816,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_057_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_057_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_057_Green/imaging_plane -> /general/optophysiology/Zstack0033_green
+/acquisition/ROI_057_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x14540414"
 /acquisition/ROI_057_Green/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_057_Red
@@ -1719,6 +1832,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_057_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_057_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_057_Red/imaging_plane -> /general/optophysiology/Zstack0033_red
+/acquisition/ROI_057_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x14540414"
 /acquisition/ROI_057_Red/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_058_Green
@@ -1734,6 +1848,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_058_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_058_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_058_Green/imaging_plane -> /general/optophysiology/Zstack0033_green
+/acquisition/ROI_058_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x16860460"
 /acquisition/ROI_058_Green/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_058_Red
@@ -1749,6 +1864,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_058_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_058_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_058_Red/imaging_plane -> /general/optophysiology/Zstack0033_red
+/acquisition/ROI_058_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x16860460"
 /acquisition/ROI_058_Red/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_059_Green
@@ -1764,6 +1880,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_059_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_059_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_059_Green/imaging_plane -> /general/optophysiology/Zstack0033_green
+/acquisition/ROI_059_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x115c03a5"
 /acquisition/ROI_059_Green/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_059_Red
@@ -1779,6 +1896,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_059_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_059_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_059_Red/imaging_plane -> /general/optophysiology/Zstack0033_red
+/acquisition/ROI_059_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x115c03a5"
 /acquisition/ROI_059_Red/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_060_Green
@@ -1794,6 +1912,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_060_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_060_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_060_Green/imaging_plane -> /general/optophysiology/Zstack0033_green
+/acquisition/ROI_060_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xef4034b"
 /acquisition/ROI_060_Green/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_060_Red
@@ -1809,6 +1928,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_060_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_060_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_060_Red/imaging_plane -> /general/optophysiology/Zstack0033_red
+/acquisition/ROI_060_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xef4034b"
 /acquisition/ROI_060_Red/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_061_Green
@@ -1824,6 +1944,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_061_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_061_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_061_Green/imaging_plane -> /general/optophysiology/Zstack0039_green
+/acquisition/ROI_061_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x108b0311"
 /acquisition/ROI_061_Green/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_061_Red
@@ -1839,6 +1960,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_061_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_061_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_061_Red/imaging_plane -> /general/optophysiology/Zstack0039_red
+/acquisition/ROI_061_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x108b0311"
 /acquisition/ROI_061_Red/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_062_Green
@@ -1854,6 +1976,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_062_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_062_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_062_Green/imaging_plane -> /general/optophysiology/Zstack0039_green
+/acquisition/ROI_062_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xe2b02b8"
 /acquisition/ROI_062_Green/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_062_Red
@@ -1869,6 +1992,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_062_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_062_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_062_Red/imaging_plane -> /general/optophysiology/Zstack0039_red
+/acquisition/ROI_062_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xe2b02b8"
 /acquisition/ROI_062_Red/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_063_Green
@@ -1884,6 +2008,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_063_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_063_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_063_Green/imaging_plane -> /general/optophysiology/Zstack0039_green
+/acquisition/ROI_063_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xac4025e"
 /acquisition/ROI_063_Green/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_063_Red
@@ -1899,6 +2024,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_063_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_063_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_063_Red/imaging_plane -> /general/optophysiology/Zstack0039_red
+/acquisition/ROI_063_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xac4025e"
 /acquisition/ROI_063_Red/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_064_Green
@@ -1914,6 +2040,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_064_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_064_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_064_Green/imaging_plane -> /general/optophysiology/Zstack0039_green
+/acquisition/ROI_064_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x11550402"
 /acquisition/ROI_064_Green/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_064_Red
@@ -1929,6 +2056,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_064_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_064_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_064_Red/imaging_plane -> /general/optophysiology/Zstack0039_red
+/acquisition/ROI_064_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x11550402"
 /acquisition/ROI_064_Red/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_065_Green
@@ -1944,6 +2072,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_065_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_065_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_065_Green/imaging_plane -> /general/optophysiology/Zstack0039_green
+/acquisition/ROI_065_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x15e704a7"
 /acquisition/ROI_065_Green/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_065_Red
@@ -1959,6 +2088,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_065_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_065_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_065_Red/imaging_plane -> /general/optophysiology/Zstack0039_red
+/acquisition/ROI_065_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x15e704a7"
 /acquisition/ROI_065_Red/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_066_Green
@@ -1974,6 +2104,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_066_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_066_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_066_Green/imaging_plane -> /general/optophysiology/Zstack0040_green
+/acquisition/ROI_066_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x1089034f"
 /acquisition/ROI_066_Green/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_066_Red
@@ -1989,6 +2120,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_066_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_066_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_066_Red/imaging_plane -> /general/optophysiology/Zstack0040_red
+/acquisition/ROI_066_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x1089034f"
 /acquisition/ROI_066_Red/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_067_Green
@@ -2004,6 +2136,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_067_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_067_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_067_Green/imaging_plane -> /general/optophysiology/Zstack0040_green
+/acquisition/ROI_067_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xf2002f5"
 /acquisition/ROI_067_Green/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_067_Red
@@ -2019,6 +2152,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_067_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_067_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_067_Red/imaging_plane -> /general/optophysiology/Zstack0040_red
+/acquisition/ROI_067_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xf2002f5"
 /acquisition/ROI_067_Red/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_068_Green
@@ -2034,6 +2168,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_068_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_068_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_068_Green/imaging_plane -> /general/optophysiology/Zstack0047_green
+/acquisition/ROI_068_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x10b5039a"
 /acquisition/ROI_068_Green/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_068_Red
@@ -2049,6 +2184,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_068_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_068_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_068_Red/imaging_plane -> /general/optophysiology/Zstack0047_red
+/acquisition/ROI_068_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x10b5039a"
 /acquisition/ROI_068_Red/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_069_Green
@@ -2064,6 +2200,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_069_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_069_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_069_Green/imaging_plane -> /general/optophysiology/Zstack0047_green
+/acquisition/ROI_069_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x1a43053e"
 /acquisition/ROI_069_Green/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_069_Red
@@ -2079,6 +2216,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_069_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_069_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_069_Red/imaging_plane -> /general/optophysiology/Zstack0047_red
+/acquisition/ROI_069_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x1a43053e"
 /acquisition/ROI_069_Red/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_070_Green
@@ -2094,6 +2232,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_070_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_070_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_070_Green/imaging_plane -> /general/optophysiology/Zstack0047_green
+/acquisition/ROI_070_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x14e503e6"
 /acquisition/ROI_070_Green/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_070_Red
@@ -2109,6 +2248,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_070_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_070_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_070_Red/imaging_plane -> /general/optophysiology/Zstack0047_red
+/acquisition/ROI_070_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x14e503e6"
 /acquisition/ROI_070_Red/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_071_Green
@@ -2124,6 +2264,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_071_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_071_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_071_Green/imaging_plane -> /general/optophysiology/Zstack0047_green
+/acquisition/ROI_071_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x117e038c"
 /acquisition/ROI_071_Green/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_071_Red
@@ -2139,6 +2280,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_071_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_071_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_071_Red/imaging_plane -> /general/optophysiology/Zstack0047_red
+/acquisition/ROI_071_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x117e038c"
 /acquisition/ROI_071_Red/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_072_Green
@@ -2154,6 +2296,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_072_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_072_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_072_Green/imaging_plane -> /general/optophysiology/Zstack0047_green
+/acquisition/ROI_072_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x13130431"
 /acquisition/ROI_072_Green/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_072_Red
@@ -2169,6 +2312,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_072_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_072_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_072_Red/imaging_plane -> /general/optophysiology/Zstack0047_red
+/acquisition/ROI_072_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x13130431"
 /acquisition/ROI_072_Red/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_073_Green
@@ -2184,6 +2328,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_073_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_073_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_073_Green/imaging_plane -> /general/optophysiology/Zstack0047_green
+/acquisition/ROI_073_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xab802d9"
 /acquisition/ROI_073_Green/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_073_Red
@@ -2199,6 +2344,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_073_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_073_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_073_Red/imaging_plane -> /general/optophysiology/Zstack0047_red
+/acquisition/ROI_073_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xab802d9"
 /acquisition/ROI_073_Red/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_074_Green
@@ -2214,6 +2360,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_074_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_074_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_074_Green/imaging_plane -> /general/optophysiology/Zstack0047_green
+/acquisition/ROI_074_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xc4c027f"
 /acquisition/ROI_074_Green/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_074_Red
@@ -2229,6 +2376,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_074_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_074_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_074_Red/imaging_plane -> /general/optophysiology/Zstack0047_red
+/acquisition/ROI_074_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xc4c027f"
 /acquisition/ROI_074_Red/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_075_Green
@@ -2244,6 +2392,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_075_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_075_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_075_Green/imaging_plane -> /general/optophysiology/Zstack0047_green
+/acquisition/ROI_075_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xee00324"
 /acquisition/ROI_075_Green/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_075_Red
@@ -2259,6 +2408,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_075_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_075_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_075_Red/imaging_plane -> /general/optophysiology/Zstack0047_red
+/acquisition/ROI_075_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xee00324"
 /acquisition/ROI_075_Red/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_076_Green
@@ -2274,6 +2424,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_076_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_076_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_076_Green/imaging_plane -> /general/optophysiology/Zstack0029_green
+/acquisition/ROI_076_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x137203c9"
 /acquisition/ROI_076_Green/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_076_Red
@@ -2289,6 +2440,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_076_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_076_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_076_Red/imaging_plane -> /general/optophysiology/Zstack0029_red
+/acquisition/ROI_076_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x137203c9"
 /acquisition/ROI_076_Red/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_077_Green
@@ -2304,6 +2456,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_077_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_077_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_077_Green/imaging_plane -> /general/optophysiology/Zstack0029_green
+/acquisition/ROI_077_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x150f046f"
 /acquisition/ROI_077_Green/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_077_Red
@@ -2319,6 +2472,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_077_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_077_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_077_Red/imaging_plane -> /general/optophysiology/Zstack0029_red
+/acquisition/ROI_077_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x150f046f"
 /acquisition/ROI_077_Red/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_078_Green
@@ -2334,6 +2488,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_078_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_078_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_078_Green/imaging_plane -> /general/optophysiology/Zstack0029_green
+/acquisition/ROI_078_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x19a10514"
 /acquisition/ROI_078_Green/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_078_Red
@@ -2349,6 +2504,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_078_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_078_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_078_Red/imaging_plane -> /general/optophysiology/Zstack0029_red
+/acquisition/ROI_078_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x19a10514"
 /acquisition/ROI_078_Red/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_079_Green
@@ -2364,6 +2520,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_079_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_079_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_079_Green/imaging_plane -> /general/optophysiology/Zstack0029_green
+/acquisition/ROI_079_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xe4002bc"
 /acquisition/ROI_079_Green/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_079_Red
@@ -2379,6 +2536,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_079_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_079_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_079_Red/imaging_plane -> /general/optophysiology/Zstack0029_red
+/acquisition/ROI_079_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xe4002bc"
 /acquisition/ROI_079_Red/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_080_Green
@@ -2394,6 +2552,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_080_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_080_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_080_Green/imaging_plane -> /general/optophysiology/Zstack0029_green
+/acquisition/ROI_080_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xae10263"
 /acquisition/ROI_080_Green/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/ROI_080_Red
@@ -2409,6 +2568,7 @@ Generating signature for 161215_15_34_21.nwb
 /acquisition/ROI_080_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_080_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_080_Red/imaging_plane -> /general/optophysiology/Zstack0029_red
+/acquisition/ROI_080_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xae10263"
 /acquisition/ROI_080_Red/timestamps: dtype=float64 shape=(175440,) val="0xcfd7a011"
 	@unit: type=str val="seconds"
 /acquisition/WhiskersCam
@@ -5090,6 +5250,7 @@ Generating signature for 161215_15_34_21.nwb
 /general/optophysiology/Zstack0049_red/reference_frame: dtype=object shape=() val="TODO: In lab book (partly?)"
 /general/session_id: dtype=object shape=() val="161215_15_34_21"
 /general/silverlab_metadata
+	@labview_version: type=str val="pre-2018 (original)"
 	@silverlab_api_version: type=str val="0.2"
 /general/silverlab_optophysiology
 	@cycle_time: dtype=float64 shape=() val="0.00286745"
@@ -5124,7 +5285,7 @@ Generating signature for 161215_15_34_21.nwb
 /processing/Acquired_ROIs
 	@description: type=str val="ROI locations and acquired fluorescence readings made directly by the AOL microscope."
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0027_green
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0027_green/angle_deg: dtype=float64 shape=(2,) val="0x100001"
 	@description: type=str val="Angle (deg)"
@@ -5146,8 +5307,6 @@ Generating signature for 161215_15_34_21.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0027_green/pixel_mask_index: dtype=int64 shape=(2,) val="0x300004"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0027_green/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0027_green/pixel_time_offsets: dtype=float64 shape=(2, 1) val="0x49c707e5"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0027_green/reference_images/Zstack_Red_0027 -> /acquisition/Zstack_Red_0027
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0027_green/reference_images/reference_images -> /acquisition/Zstack_Red_0027
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0027_green/roi_group_id: dtype=float64 shape=(2,) val="0x100001"
@@ -5171,7 +5330,7 @@ Generating signature for 161215_15_34_21.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0027_green/zoom: dtype=float64 shape=(2,) val="0xdc6025f"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0027_red
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0027_red/angle_deg: dtype=float64 shape=(2,) val="0x100001"
 	@description: type=str val="Angle (deg)"
@@ -5193,8 +5352,6 @@ Generating signature for 161215_15_34_21.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0027_red/pixel_mask_index: dtype=int64 shape=(2,) val="0x300004"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0027_red/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0027_red/pixel_time_offsets: dtype=float64 shape=(2, 1) val="0x49c707e5"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0027_red/reference_images/Zstack_Red_0027 -> /acquisition/Zstack_Red_0027
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0027_red/reference_images/reference_images -> /acquisition/Zstack_Red_0027
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0027_red/roi_group_id: dtype=float64 shape=(2,) val="0x100001"
@@ -5218,7 +5375,7 @@ Generating signature for 161215_15_34_21.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0027_red/zoom: dtype=float64 shape=(2,) val="0xdc6025f"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0029_green
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0029_green/angle_deg: dtype=float64 shape=(10,) val="0x500001"
 	@description: type=str val="Angle (deg)"
@@ -5240,8 +5397,6 @@ Generating signature for 161215_15_34_21.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0029_green/pixel_mask_index: dtype=int64 shape=(10,) val="0x7300038"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0029_green/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0029_green/pixel_time_offsets: dtype=float64 shape=(10, 1) val="0x9da22266"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0029_green/reference_images/Zstack_Red_0029 -> /acquisition/Zstack_Red_0029
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0029_green/reference_images/reference_images -> /acquisition/Zstack_Red_0029
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0029_green/roi_group_id: dtype=float64 shape=(10,) val="0x500001"
@@ -5265,7 +5420,7 @@ Generating signature for 161215_15_34_21.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0029_green/zoom: dtype=float64 shape=(10,) val="0xbfad0bd7"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0029_red
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0029_red/angle_deg: dtype=float64 shape=(10,) val="0x500001"
 	@description: type=str val="Angle (deg)"
@@ -5287,8 +5442,6 @@ Generating signature for 161215_15_34_21.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0029_red/pixel_mask_index: dtype=int64 shape=(10,) val="0x7300038"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0029_red/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0029_red/pixel_time_offsets: dtype=float64 shape=(10, 1) val="0x9da22266"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0029_red/reference_images/Zstack_Red_0029 -> /acquisition/Zstack_Red_0029
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0029_red/reference_images/reference_images -> /acquisition/Zstack_Red_0029
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0029_red/roi_group_id: dtype=float64 shape=(10,) val="0x500001"
@@ -5312,7 +5465,7 @@ Generating signature for 161215_15_34_21.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0029_red/zoom: dtype=float64 shape=(10,) val="0xbfad0bd7"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0030_green
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0030_green/angle_deg: dtype=float64 shape=(4,) val="0x200001"
 	@description: type=str val="Angle (deg)"
@@ -5334,8 +5487,6 @@ Generating signature for 161215_15_34_21.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0030_green/pixel_mask_index: dtype=int64 shape=(4,) val="0xc0000b"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0030_green/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0030_green/pixel_time_offsets: dtype=float64 shape=(4, 1) val="0x25c210db"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0030_green/reference_images/Zstack_Red_0030 -> /acquisition/Zstack_Red_0030
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0030_green/reference_images/reference_images -> /acquisition/Zstack_Red_0030
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0030_green/roi_group_id: dtype=float64 shape=(4,) val="0x200001"
@@ -5359,7 +5510,7 @@ Generating signature for 161215_15_34_21.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0030_green/zoom: dtype=float64 shape=(4,) val="0x416c04bd"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0030_red
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0030_red/angle_deg: dtype=float64 shape=(4,) val="0x200001"
 	@description: type=str val="Angle (deg)"
@@ -5381,8 +5532,6 @@ Generating signature for 161215_15_34_21.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0030_red/pixel_mask_index: dtype=int64 shape=(4,) val="0xc0000b"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0030_red/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0030_red/pixel_time_offsets: dtype=float64 shape=(4, 1) val="0x25c210db"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0030_red/reference_images/Zstack_Red_0030 -> /acquisition/Zstack_Red_0030
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0030_red/reference_images/reference_images -> /acquisition/Zstack_Red_0030
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0030_red/roi_group_id: dtype=float64 shape=(4,) val="0x200001"
@@ -5406,7 +5555,7 @@ Generating signature for 161215_15_34_21.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0030_red/zoom: dtype=float64 shape=(4,) val="0x416c04bd"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0032_green
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0032_green/angle_deg: dtype=float64 shape=(5,) val="0x280001"
 	@description: type=str val="Angle (deg)"
@@ -5428,8 +5577,6 @@ Generating signature for 161215_15_34_21.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0032_green/pixel_mask_index: dtype=int64 shape=(5,) val="0x1400010"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0032_green/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0032_green/pixel_time_offsets: dtype=float64 shape=(5, 1) val="0x5dfb1007"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0032_green/reference_images/Zstack_Red_0032 -> /acquisition/Zstack_Red_0032
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0032_green/reference_images/reference_images -> /acquisition/Zstack_Red_0032
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0032_green/roi_group_id: dtype=float64 shape=(5,) val="0x280001"
@@ -5453,7 +5600,7 @@ Generating signature for 161215_15_34_21.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0032_green/zoom: dtype=float64 shape=(5,) val="0x697305ec"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0032_red
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0032_red/angle_deg: dtype=float64 shape=(5,) val="0x280001"
 	@description: type=str val="Angle (deg)"
@@ -5475,8 +5622,6 @@ Generating signature for 161215_15_34_21.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0032_red/pixel_mask_index: dtype=int64 shape=(5,) val="0x1400010"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0032_red/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0032_red/pixel_time_offsets: dtype=float64 shape=(5, 1) val="0x5dfb1007"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0032_red/reference_images/Zstack_Red_0032 -> /acquisition/Zstack_Red_0032
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0032_red/reference_images/reference_images -> /acquisition/Zstack_Red_0032
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0032_red/roi_group_id: dtype=float64 shape=(5,) val="0x280001"
@@ -5500,7 +5645,7 @@ Generating signature for 161215_15_34_21.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0032_red/zoom: dtype=float64 shape=(5,) val="0x697305ec"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0033_green
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0033_green/angle_deg: dtype=float64 shape=(22,) val="0xb00001"
 	@description: type=str val="Angle (deg)"
@@ -5522,8 +5667,6 @@ Generating signature for 161215_15_34_21.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0033_green/pixel_mask_index: dtype=int64 shape=(22,) val="0x3ff000fe"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0033_green/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0033_green/pixel_time_offsets: dtype=float64 shape=(22, 1) val="0x3d4550d7"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0033_green/reference_images/Zstack_Red_0033 -> /acquisition/Zstack_Red_0033
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0033_green/reference_images/reference_images -> /acquisition/Zstack_Red_0033
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0033_green/roi_group_id: dtype=float64 shape=(22,) val="0xb00001"
@@ -5547,7 +5690,7 @@ Generating signature for 161215_15_34_21.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0033_green/zoom: dtype=float64 shape=(22,) val="0xbb1a1a0b"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0033_red
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0033_red/angle_deg: dtype=float64 shape=(22,) val="0xb00001"
 	@description: type=str val="Angle (deg)"
@@ -5569,8 +5712,6 @@ Generating signature for 161215_15_34_21.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0033_red/pixel_mask_index: dtype=int64 shape=(22,) val="0x3ff000fe"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0033_red/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0033_red/pixel_time_offsets: dtype=float64 shape=(22, 1) val="0x3d4550d7"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0033_red/reference_images/Zstack_Red_0033 -> /acquisition/Zstack_Red_0033
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0033_red/reference_images/reference_images -> /acquisition/Zstack_Red_0033
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0033_red/roi_group_id: dtype=float64 shape=(22,) val="0xb00001"
@@ -5594,7 +5735,7 @@ Generating signature for 161215_15_34_21.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0033_red/zoom: dtype=float64 shape=(22,) val="0xbb1a1a0b"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0034_green
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0034_green/angle_deg: dtype=float64 shape=(15,) val="0x780001"
 	@description: type=str val="Angle (deg)"
@@ -5616,8 +5757,6 @@ Generating signature for 161215_15_34_21.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0034_green/pixel_mask_index: dtype=int64 shape=(15,) val="0x15b80079"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0034_green/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0034_green/pixel_time_offsets: dtype=float64 shape=(15, 1) val="0x9fe13499"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0034_green/reference_images/Zstack_Red_0034 -> /acquisition/Zstack_Red_0034
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0034_green/reference_images/reference_images -> /acquisition/Zstack_Red_0034
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0034_green/roi_group_id: dtype=float64 shape=(15,) val="0x780001"
@@ -5641,7 +5780,7 @@ Generating signature for 161215_15_34_21.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0034_green/zoom: dtype=float64 shape=(15,) val="0x2bd11c2"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0034_red
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0034_red/angle_deg: dtype=float64 shape=(15,) val="0x780001"
 	@description: type=str val="Angle (deg)"
@@ -5663,8 +5802,6 @@ Generating signature for 161215_15_34_21.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0034_red/pixel_mask_index: dtype=int64 shape=(15,) val="0x15b80079"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0034_red/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0034_red/pixel_time_offsets: dtype=float64 shape=(15, 1) val="0x9fe13499"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0034_red/reference_images/Zstack_Red_0034 -> /acquisition/Zstack_Red_0034
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0034_red/reference_images/reference_images -> /acquisition/Zstack_Red_0034
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0034_red/roi_group_id: dtype=float64 shape=(15,) val="0x780001"
@@ -5688,7 +5825,7 @@ Generating signature for 161215_15_34_21.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0034_red/zoom: dtype=float64 shape=(15,) val="0x2bd11c2"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0035_green
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0035_green/angle_deg: dtype=float64 shape=(7,) val="0x380001"
 	@description: type=str val="Angle (deg)"
@@ -5710,8 +5847,6 @@ Generating signature for 161215_15_34_21.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0035_green/pixel_mask_index: dtype=int64 shape=(7,) val="0x2d8001d"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0035_green/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0035_green/pixel_time_offsets: dtype=float64 shape=(7, 1) val="0x1e4a1b59"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0035_green/reference_images/Zstack_Red_0035 -> /acquisition/Zstack_Red_0035
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0035_green/reference_images/reference_images -> /acquisition/Zstack_Red_0035
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0035_green/roi_group_id: dtype=float64 shape=(7,) val="0x380001"
@@ -5735,7 +5870,7 @@ Generating signature for 161215_15_34_21.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0035_green/zoom: dtype=float64 shape=(7,) val="0xd5e9084a"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0035_red
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0035_red/angle_deg: dtype=float64 shape=(7,) val="0x380001"
 	@description: type=str val="Angle (deg)"
@@ -5757,8 +5892,6 @@ Generating signature for 161215_15_34_21.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0035_red/pixel_mask_index: dtype=int64 shape=(7,) val="0x2d8001d"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0035_red/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0035_red/pixel_time_offsets: dtype=float64 shape=(7, 1) val="0x1e4a1b59"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0035_red/reference_images/Zstack_Red_0035 -> /acquisition/Zstack_Red_0035
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0035_red/reference_images/reference_images -> /acquisition/Zstack_Red_0035
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0035_red/roi_group_id: dtype=float64 shape=(7,) val="0x380001"
@@ -5782,7 +5915,7 @@ Generating signature for 161215_15_34_21.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0035_red/zoom: dtype=float64 shape=(7,) val="0xd5e9084a"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0039_green
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0039_green/angle_deg: dtype=float64 shape=(5,) val="0x280001"
 	@description: type=str val="Angle (deg)"
@@ -5804,8 +5937,6 @@ Generating signature for 161215_15_34_21.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0039_green/pixel_mask_index: dtype=int64 shape=(5,) val="0x1400010"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0039_green/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0039_green/pixel_time_offsets: dtype=float64 shape=(5, 1) val="0x39c510cc"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0039_green/reference_images/Zstack_Red_0039 -> /acquisition/Zstack_Red_0039
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0039_green/reference_images/reference_images -> /acquisition/Zstack_Red_0039
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0039_green/roi_group_id: dtype=float64 shape=(5,) val="0x280001"
@@ -5829,7 +5960,7 @@ Generating signature for 161215_15_34_21.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0039_green/zoom: dtype=float64 shape=(5,) val="0x697305ec"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0039_red
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0039_red/angle_deg: dtype=float64 shape=(5,) val="0x280001"
 	@description: type=str val="Angle (deg)"
@@ -5851,8 +5982,6 @@ Generating signature for 161215_15_34_21.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0039_red/pixel_mask_index: dtype=int64 shape=(5,) val="0x1400010"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0039_red/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0039_red/pixel_time_offsets: dtype=float64 shape=(5, 1) val="0x39c510cc"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0039_red/reference_images/Zstack_Red_0039 -> /acquisition/Zstack_Red_0039
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0039_red/reference_images/reference_images -> /acquisition/Zstack_Red_0039
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0039_red/roi_group_id: dtype=float64 shape=(5,) val="0x280001"
@@ -5876,7 +6005,7 @@ Generating signature for 161215_15_34_21.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0039_red/zoom: dtype=float64 shape=(5,) val="0x697305ec"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0040_green
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0040_green/angle_deg: dtype=float64 shape=(2,) val="0x100001"
 	@description: type=str val="Angle (deg)"
@@ -5898,8 +6027,6 @@ Generating signature for 161215_15_34_21.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0040_green/pixel_mask_index: dtype=int64 shape=(2,) val="0x300004"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0040_green/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0040_green/pixel_time_offsets: dtype=float64 shape=(2, 1) val="0x3a190643"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0040_green/reference_images/Zstack_Red_0040 -> /acquisition/Zstack_Red_0040
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0040_green/reference_images/reference_images -> /acquisition/Zstack_Red_0040
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0040_green/roi_group_id: dtype=float64 shape=(2,) val="0x100001"
@@ -5923,7 +6050,7 @@ Generating signature for 161215_15_34_21.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0040_green/zoom: dtype=float64 shape=(2,) val="0xdc6025f"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0040_red
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0040_red/angle_deg: dtype=float64 shape=(2,) val="0x100001"
 	@description: type=str val="Angle (deg)"
@@ -5945,8 +6072,6 @@ Generating signature for 161215_15_34_21.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0040_red/pixel_mask_index: dtype=int64 shape=(2,) val="0x300004"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0040_red/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0040_red/pixel_time_offsets: dtype=float64 shape=(2, 1) val="0x3a190643"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0040_red/reference_images/Zstack_Red_0040 -> /acquisition/Zstack_Red_0040
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0040_red/reference_images/reference_images -> /acquisition/Zstack_Red_0040
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0040_red/roi_group_id: dtype=float64 shape=(2,) val="0x100001"
@@ -5970,7 +6095,7 @@ Generating signature for 161215_15_34_21.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0040_red/zoom: dtype=float64 shape=(2,) val="0xdc6025f"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0047_green
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0047_green/angle_deg: dtype=float64 shape=(8,) val="0x400001"
 	@description: type=str val="Angle (deg)"
@@ -5992,8 +6117,6 @@ Generating signature for 161215_15_34_21.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0047_green/pixel_mask_index: dtype=int64 shape=(8,) val="0x4000025"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0047_green/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0047_green/pixel_time_offsets: dtype=float64 shape=(8, 1) val="0x28e1cf0"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0047_green/reference_images/Zstack_Red_0047 -> /acquisition/Zstack_Red_0047
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0047_green/reference_images/reference_images -> /acquisition/Zstack_Red_0047
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0047_green/roi_group_id: dtype=float64 shape=(8,) val="0x400001"
@@ -6017,7 +6140,7 @@ Generating signature for 161215_15_34_21.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0047_green/zoom: dtype=float64 shape=(8,) val="0x1a670979"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0047_red
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0047_red/angle_deg: dtype=float64 shape=(8,) val="0x400001"
 	@description: type=str val="Angle (deg)"
@@ -6039,8 +6162,6 @@ Generating signature for 161215_15_34_21.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0047_red/pixel_mask_index: dtype=int64 shape=(8,) val="0x4000025"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0047_red/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0047_red/pixel_time_offsets: dtype=float64 shape=(8, 1) val="0x28e1cf0"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0047_red/reference_images/Zstack_Red_0047 -> /acquisition/Zstack_Red_0047
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0047_red/reference_images/reference_images -> /acquisition/Zstack_Red_0047
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0047_red/roi_group_id: dtype=float64 shape=(8,) val="0x400001"
@@ -6065,9 +6186,10 @@ Generating signature for 161215_15_34_21.nwb
 	@description: type=str val="Zoom"
 /session_description: dtype=object shape=() val="One or two sentences descri...0x65b618d5"
 /session_start_time: dtype=object shape=() val="2016-12-15T15:23:11.436200+...0x6a4f0664"
-/specifications/silverlab_extended_schema/0.2/namespace: dtype=object shape=() val="{"namespaces":[{"doc":"Exte...0x5f6a6a92"
-/specifications/silverlab_extended_schema/0.2/silverlab.metadata: dtype=object shape=() val="{"groups":[{"doc":"A place ...0xc0d670ae"
-/specifications/silverlab_extended_schema/0.2/silverlab.ophys: dtype=object shape=() val="{"groups":[{"datasets":[{"s...0xeab28ad7"
+/specifications/silverlab_extended_schema/0.3/namespace: dtype=object shape=() val="{"namespaces":[{"doc":"Exte...0x2db67446"
+/specifications/silverlab_extended_schema/0.3/silverlab.metadata: dtype=object shape=() val="{"groups":[{"doc":"A place ...0x908295e2"
+/specifications/silverlab_extended_schema/0.3/silverlab.ophys: dtype=object shape=() val="{"groups":[{"datasets":[{"s...0xeab28ad7"
+/specifications/silverlab_extended_schema/0.3/silverlab.roi: dtype=object shape=() val="{"groups":[{"datasets":[{"s...0x5c700123"
 /stimulus/presentation/air_puff
 	@comments: type=str val="Delivered 'instantaneously' at the specified times"
 	@description: type=str val="Air puff stimulus"

--- a/tests/data/161215_15_34_21.sig2
+++ b/tests/data/161215_15_34_21.sig2
@@ -6186,10 +6186,6 @@ Generating signature for 161215_15_34_21.nwb
 	@description: type=str val="Zoom"
 /session_description: dtype=object shape=() val="One or two sentences descri...0x65b618d5"
 /session_start_time: dtype=object shape=() val="2016-12-15T15:23:11.436200+...0x6a4f0664"
-/specifications/silverlab_extended_schema/0.3/namespace: dtype=object shape=() val="{"namespaces":[{"doc":"Exte...0x2db67446"
-/specifications/silverlab_extended_schema/0.3/silverlab.metadata: dtype=object shape=() val="{"groups":[{"doc":"A place ...0x908295e2"
-/specifications/silverlab_extended_schema/0.3/silverlab.ophys: dtype=object shape=() val="{"groups":[{"datasets":[{"s...0xeab28ad7"
-/specifications/silverlab_extended_schema/0.3/silverlab.roi: dtype=object shape=() val="{"groups":[{"datasets":[{"s...0x5c700123"
 /stimulus/presentation/air_puff
 	@comments: type=str val="Delivered 'instantaneously' at the specified times"
 	@description: type=str val="Air puff stimulus"

--- a/tests/data/161215_15_58_52.sig2
+++ b/tests/data/161215_15_58_52.sig2
@@ -6258,10 +6258,6 @@ Generating signature for 161215_15_58_52.nwb
 	@description: type=str val="Zoom"
 /session_description: dtype=object shape=() val="One or two sentences descri...0x65b618d5"
 /session_start_time: dtype=object shape=() val="2016-12-15T16:03:24.978909+...0x6b720682"
-/specifications/silverlab_extended_schema/0.3/namespace: dtype=object shape=() val="{"namespaces":[{"doc":"Exte...0x2db67446"
-/specifications/silverlab_extended_schema/0.3/silverlab.metadata: dtype=object shape=() val="{"groups":[{"doc":"A place ...0x908295e2"
-/specifications/silverlab_extended_schema/0.3/silverlab.ophys: dtype=object shape=() val="{"groups":[{"datasets":[{"s...0xeab28ad7"
-/specifications/silverlab_extended_schema/0.3/silverlab.roi: dtype=object shape=() val="{"groups":[{"datasets":[{"s...0x5c700123"
 /stimulus/presentation/air_puff
 	@comments: type=str val="Delivered 'instantaneously' at the specified times"
 	@description: type=str val="Air puff stimulus"

--- a/tests/data/161215_15_58_52.sig2
+++ b/tests/data/161215_15_58_52.sig2
@@ -15,6 +15,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_001_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_001_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_001_Green/imaging_plane -> /general/optophysiology/Zstack0025_green
+/acquisition/ROI_001_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xcb50321"
 /acquisition/ROI_001_Green/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_001_Red
@@ -30,6 +31,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_001_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_001_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_001_Red/imaging_plane -> /general/optophysiology/Zstack0025_red
+/acquisition/ROI_001_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xcb50321"
 /acquisition/ROI_001_Red/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_002_Green
@@ -45,6 +47,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_002_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_002_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_002_Green/imaging_plane -> /general/optophysiology/Zstack0025_green
+/acquisition/ROI_002_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xe730350"
 /acquisition/ROI_002_Green/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_002_Red
@@ -60,6 +63,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_002_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_002_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_002_Red/imaging_plane -> /general/optophysiology/Zstack0025_red
+/acquisition/ROI_002_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xe730350"
 /acquisition/ROI_002_Red/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_003_Green
@@ -75,6 +79,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_003_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_003_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_003_Green/imaging_plane -> /general/optophysiology/Zstack0029_green
+/acquisition/ROI_003_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xf32037f"
 /acquisition/ROI_003_Green/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_003_Red
@@ -90,6 +95,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_003_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_003_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_003_Red/imaging_plane -> /general/optophysiology/Zstack0029_red
+/acquisition/ROI_003_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xf32037f"
 /acquisition/ROI_003_Red/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_004_Green
@@ -105,6 +111,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_004_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_004_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_004_Green/imaging_plane -> /general/optophysiology/Zstack0029_green
+/acquisition/ROI_004_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x18f104ae"
 /acquisition/ROI_004_Green/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_004_Red
@@ -120,6 +127,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_004_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_004_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_004_Red/imaging_plane -> /general/optophysiology/Zstack0029_red
+/acquisition/ROI_004_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x18f104ae"
 /acquisition/ROI_004_Red/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_005_Green
@@ -135,6 +143,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_005_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_005_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_005_Green/imaging_plane -> /general/optophysiology/Zstack0029_green
+/acquisition/ROI_005_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xeb902df"
 /acquisition/ROI_005_Green/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_005_Red
@@ -150,6 +159,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_005_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_005_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_005_Red/imaging_plane -> /general/optophysiology/Zstack0029_red
+/acquisition/ROI_005_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xeb902df"
 /acquisition/ROI_005_Red/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_006_Green
@@ -165,6 +175,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_006_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_006_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_006_Green/imaging_plane -> /general/optophysiology/Zstack0029_green
+/acquisition/ROI_006_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x1077030e"
 /acquisition/ROI_006_Green/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_006_Red
@@ -180,6 +191,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_006_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_006_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_006_Red/imaging_plane -> /general/optophysiology/Zstack0029_red
+/acquisition/ROI_006_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x1077030e"
 /acquisition/ROI_006_Red/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_007_Green
@@ -195,6 +207,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_007_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_007_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_007_Green/imaging_plane -> /general/optophysiology/Zstack0029_green
+/acquisition/ROI_007_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x167703dd"
 /acquisition/ROI_007_Green/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_007_Red
@@ -210,6 +223,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_007_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_007_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_007_Red/imaging_plane -> /general/optophysiology/Zstack0029_red
+/acquisition/ROI_007_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x167703dd"
 /acquisition/ROI_007_Red/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_008_Green
@@ -225,6 +239,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_008_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_008_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_008_Green/imaging_plane -> /general/optophysiology/Zstack0029_green
+/acquisition/ROI_008_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x12da0375"
 /acquisition/ROI_008_Green/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_008_Red
@@ -240,6 +255,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_008_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_008_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_008_Red/imaging_plane -> /general/optophysiology/Zstack0029_red
+/acquisition/ROI_008_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x12da0375"
 /acquisition/ROI_008_Red/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_009_Green
@@ -255,6 +271,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_009_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_009_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_009_Green/imaging_plane -> /general/optophysiology/Zstack0028_green
+/acquisition/ROI_009_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xe3e030d"
 /acquisition/ROI_009_Green/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_009_Red
@@ -270,6 +287,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_009_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_009_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_009_Red/imaging_plane -> /general/optophysiology/Zstack0028_red
+/acquisition/ROI_009_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xe3e030d"
 /acquisition/ROI_009_Red/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_010_Green
@@ -285,6 +303,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_010_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_010_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_010_Green/imaging_plane -> /general/optophysiology/Zstack0028_green
+/acquisition/ROI_010_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xaa102a5"
 /acquisition/ROI_010_Green/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_010_Red
@@ -300,6 +319,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_010_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_010_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_010_Red/imaging_plane -> /general/optophysiology/Zstack0028_red
+/acquisition/ROI_010_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xaa102a5"
 /acquisition/ROI_010_Red/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_011_Green
@@ -315,6 +335,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_011_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_011_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_011_Green/imaging_plane -> /general/optophysiology/Zstack0028_green
+/acquisition/ROI_011_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x14f8043b"
 /acquisition/ROI_011_Green/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_011_Red
@@ -330,6 +351,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_011_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_011_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_011_Red/imaging_plane -> /general/optophysiology/Zstack0028_red
+/acquisition/ROI_011_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x14f8043b"
 /acquisition/ROI_011_Red/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_012_Green
@@ -345,6 +367,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_012_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_012_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_012_Green/imaging_plane -> /general/optophysiology/Zstack0028_green
+/acquisition/ROI_012_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x115b03d3"
 /acquisition/ROI_012_Green/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_012_Red
@@ -360,6 +383,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_012_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_012_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_012_Red/imaging_plane -> /general/optophysiology/Zstack0028_red
+/acquisition/ROI_012_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x115b03d3"
 /acquisition/ROI_012_Red/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_013_Green
@@ -375,6 +399,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_013_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_013_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_013_Green/imaging_plane -> /general/optophysiology/Zstack0028_green
+/acquisition/ROI_013_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x10bb036b"
 /acquisition/ROI_013_Green/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_013_Red
@@ -390,6 +415,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_013_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_013_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_013_Red/imaging_plane -> /general/optophysiology/Zstack0028_red
+/acquisition/ROI_013_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x10bb036b"
 /acquisition/ROI_013_Red/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_014_Green
@@ -405,6 +431,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_014_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_014_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_014_Green/imaging_plane -> /general/optophysiology/Zstack0033_green
+/acquisition/ROI_014_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x13190402"
 /acquisition/ROI_014_Green/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_014_Red
@@ -420,6 +447,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_014_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_014_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_014_Red/imaging_plane -> /general/optophysiology/Zstack0033_red
+/acquisition/ROI_014_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x13190402"
 /acquisition/ROI_014_Red/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_015_Green
@@ -435,6 +463,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_015_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_015_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_015_Green/imaging_plane -> /general/optophysiology/Zstack0033_green
+/acquisition/ROI_015_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x177d049a"
 /acquisition/ROI_015_Green/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_015_Red
@@ -450,6 +479,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_015_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_015_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_015_Red/imaging_plane -> /general/optophysiology/Zstack0033_red
+/acquisition/ROI_015_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x177d049a"
 /acquisition/ROI_015_Red/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_016_Green
@@ -465,6 +495,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_016_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_016_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_016_Green/imaging_plane -> /general/optophysiology/Zstack0033_green
+/acquisition/ROI_016_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xee40333"
 /acquisition/ROI_016_Green/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_016_Red
@@ -480,6 +511,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_016_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_016_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_016_Red/imaging_plane -> /general/optophysiology/Zstack0033_red
+/acquisition/ROI_016_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xee40333"
 /acquisition/ROI_016_Red/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_017_Green
@@ -495,6 +527,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_017_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_017_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_017_Green/imaging_plane -> /general/optophysiology/Zstack0034_green
+/acquisition/ROI_017_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x124103ca"
 /acquisition/ROI_017_Green/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_017_Red
@@ -510,6 +543,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_017_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_017_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_017_Red/imaging_plane -> /general/optophysiology/Zstack0034_red
+/acquisition/ROI_017_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x124103ca"
 /acquisition/ROI_017_Red/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_018_Green
@@ -525,6 +559,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_018_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_018_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_018_Green/imaging_plane -> /general/optophysiology/Zstack0034_green
+/acquisition/ROI_018_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xea40362"
 /acquisition/ROI_018_Green/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_018_Red
@@ -540,6 +575,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_018_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_018_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_018_Red/imaging_plane -> /general/optophysiology/Zstack0034_red
+/acquisition/ROI_018_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xea40362"
 /acquisition/ROI_018_Red/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_019_Green
@@ -555,6 +591,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_019_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_019_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_019_Green/imaging_plane -> /general/optophysiology/Zstack0034_green
+/acquisition/ROI_019_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xf0302fa"
 /acquisition/ROI_019_Green/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_019_Red
@@ -570,6 +607,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_019_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_019_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_019_Red/imaging_plane -> /general/optophysiology/Zstack0034_red
+/acquisition/ROI_019_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xf0302fa"
 /acquisition/ROI_019_Red/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_020_Green
@@ -585,6 +623,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_020_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_020_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_020_Green/imaging_plane -> /general/optophysiology/Zstack0034_green
+/acquisition/ROI_020_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xc650292"
 /acquisition/ROI_020_Green/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_020_Red
@@ -600,6 +639,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_020_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_020_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_020_Red/imaging_plane -> /general/optophysiology/Zstack0034_red
+/acquisition/ROI_020_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xc650292"
 /acquisition/ROI_020_Red/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_021_Green
@@ -615,6 +655,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_021_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_021_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_021_Green/imaging_plane -> /general/optophysiology/Zstack0034_green
+/acquisition/ROI_021_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x10c10329"
 /acquisition/ROI_021_Green/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_021_Red
@@ -630,6 +671,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_021_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_021_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_021_Red/imaging_plane -> /general/optophysiology/Zstack0034_red
+/acquisition/ROI_021_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x10c10329"
 /acquisition/ROI_021_Red/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_022_Green
@@ -645,6 +687,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_022_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_022_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_022_Green/imaging_plane -> /general/optophysiology/Zstack0034_green
+/acquisition/ROI_022_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x151d03c0"
 /acquisition/ROI_022_Green/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_022_Red
@@ -660,6 +703,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_022_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_022_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_022_Red/imaging_plane -> /general/optophysiology/Zstack0034_red
+/acquisition/ROI_022_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x151d03c0"
 /acquisition/ROI_022_Red/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_023_Green
@@ -675,6 +719,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_023_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_023_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_023_Green/imaging_plane -> /general/optophysiology/Zstack0034_green
+/acquisition/ROI_023_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xc840259"
 /acquisition/ROI_023_Green/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_023_Red
@@ -690,6 +735,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_023_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_023_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_023_Red/imaging_plane -> /general/optophysiology/Zstack0034_red
+/acquisition/ROI_023_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xc840259"
 /acquisition/ROI_023_Red/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_024_Green
@@ -705,6 +751,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_024_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_024_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_024_Green/imaging_plane -> /general/optophysiology/Zstack0034_green
+/acquisition/ROI_024_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x19e104ef"
 /acquisition/ROI_024_Green/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_024_Red
@@ -720,6 +767,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_024_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_024_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_024_Red/imaging_plane -> /general/optophysiology/Zstack0034_red
+/acquisition/ROI_024_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x19e104ef"
 /acquisition/ROI_024_Red/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_025_Green
@@ -735,6 +783,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_025_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_025_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_025_Green/imaging_plane -> /general/optophysiology/Zstack0034_green
+/acquisition/ROI_025_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x110d038a"
 /acquisition/ROI_025_Green/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_025_Red
@@ -750,6 +799,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_025_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_025_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_025_Red/imaging_plane -> /general/optophysiology/Zstack0034_red
+/acquisition/ROI_025_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x110d038a"
 /acquisition/ROI_025_Red/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_026_Green
@@ -765,6 +815,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_026_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_026_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_026_Green/imaging_plane -> /general/optophysiology/Zstack0034_green
+/acquisition/ROI_026_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x124003d6"
 /acquisition/ROI_026_Green/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_026_Red
@@ -780,6 +831,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_026_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_026_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_026_Red/imaging_plane -> /general/optophysiology/Zstack0034_red
+/acquisition/ROI_026_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x124003d6"
 /acquisition/ROI_026_Red/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_027_Green
@@ -795,6 +847,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_027_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_027_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_027_Green/imaging_plane -> /general/optophysiology/Zstack0035_green
+/acquisition/ROI_027_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xd780323"
 /acquisition/ROI_027_Green/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_027_Red
@@ -810,6 +863,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_027_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_027_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_027_Red/imaging_plane -> /general/optophysiology/Zstack0035_red
+/acquisition/ROI_027_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xd780323"
 /acquisition/ROI_027_Red/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_028_Green
@@ -825,6 +879,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_028_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_028_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_028_Green/imaging_plane -> /general/optophysiology/Zstack0035_green
+/acquisition/ROI_028_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xfa2036e"
 /acquisition/ROI_028_Green/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_028_Red
@@ -840,6 +895,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_028_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_028_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_028_Red/imaging_plane -> /general/optophysiology/Zstack0035_red
+/acquisition/ROI_028_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xfa2036e"
 /acquisition/ROI_028_Red/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_029_Green
@@ -855,6 +911,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_029_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_029_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_029_Green/imaging_plane -> /general/optophysiology/Zstack0035_green
+/acquisition/ROI_029_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x11d403ba"
 /acquisition/ROI_029_Green/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_029_Red
@@ -870,6 +927,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_029_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_029_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_029_Red/imaging_plane -> /general/optophysiology/Zstack0035_red
+/acquisition/ROI_029_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x11d403ba"
 /acquisition/ROI_029_Red/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_030_Green
@@ -885,6 +943,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_030_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_030_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_030_Green/imaging_plane -> /general/optophysiology/Zstack0035_green
+/acquisition/ROI_030_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x14060406"
 /acquisition/ROI_030_Green/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_030_Red
@@ -900,6 +959,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_030_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_030_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_030_Red/imaging_plane -> /general/optophysiology/Zstack0035_red
+/acquisition/ROI_030_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x14060406"
 /acquisition/ROI_030_Red/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_031_Green
@@ -915,6 +975,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_031_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_031_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_031_Green/imaging_plane -> /general/optophysiology/Zstack0035_green
+/acquisition/ROI_031_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xf360352"
 /acquisition/ROI_031_Green/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_031_Red
@@ -930,6 +991,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_031_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_031_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_031_Red/imaging_plane -> /general/optophysiology/Zstack0035_red
+/acquisition/ROI_031_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xf360352"
 /acquisition/ROI_031_Red/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_032_Green
@@ -945,6 +1007,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_032_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_032_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_032_Green/imaging_plane -> /general/optophysiology/Zstack0035_green
+/acquisition/ROI_032_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x1069039e"
 /acquisition/ROI_032_Green/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_032_Red
@@ -960,6 +1023,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_032_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_032_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_032_Red/imaging_plane -> /general/optophysiology/Zstack0035_red
+/acquisition/ROI_032_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x1069039e"
 /acquisition/ROI_032_Red/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_033_Green
@@ -975,6 +1039,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_033_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_033_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_033_Green/imaging_plane -> /general/optophysiology/Zstack0033_green
+/acquisition/ROI_033_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xf9502ea"
 /acquisition/ROI_033_Green/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_033_Red
@@ -990,6 +1055,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_033_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_033_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_033_Red/imaging_plane -> /general/optophysiology/Zstack0033_red
+/acquisition/ROI_033_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xf9502ea"
 /acquisition/ROI_033_Red/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_034_Green
@@ -1005,6 +1071,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_034_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_034_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_034_Green/imaging_plane -> /general/optophysiology/Zstack0033_green
+/acquisition/ROI_034_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x15c40435"
 /acquisition/ROI_034_Green/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_034_Red
@@ -1020,6 +1087,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_034_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_034_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_034_Red/imaging_plane -> /general/optophysiology/Zstack0033_red
+/acquisition/ROI_034_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x15c40435"
 /acquisition/ROI_034_Red/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_035_Green
@@ -1035,6 +1103,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_035_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_035_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_035_Green/imaging_plane -> /general/optophysiology/Zstack0033_green
+/acquisition/ROI_035_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xbf80282"
 /acquisition/ROI_035_Green/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_035_Red
@@ -1050,6 +1119,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_035_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_035_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_035_Red/imaging_plane -> /general/optophysiology/Zstack0033_red
+/acquisition/ROI_035_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xbf80282"
 /acquisition/ROI_035_Red/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_036_Green
@@ -1065,6 +1135,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_036_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_036_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_036_Green/imaging_plane -> /general/optophysiology/Zstack0033_green
+/acquisition/ROI_036_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x122703cd"
 /acquisition/ROI_036_Green/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_036_Red
@@ -1080,6 +1151,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_036_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_036_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_036_Red/imaging_plane -> /general/optophysiology/Zstack0033_red
+/acquisition/ROI_036_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x122703cd"
 /acquisition/ROI_036_Red/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_037_Green
@@ -1095,6 +1167,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_037_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_037_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_037_Green/imaging_plane -> /general/optophysiology/Zstack0033_green
+/acquisition/ROI_037_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x164f0418"
 /acquisition/ROI_037_Green/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_037_Red
@@ -1110,6 +1183,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_037_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_037_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_037_Red/imaging_plane -> /general/optophysiology/Zstack0033_red
+/acquisition/ROI_037_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x164f0418"
 /acquisition/ROI_037_Red/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_038_Green
@@ -1125,6 +1199,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_038_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_038_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_038_Green/imaging_plane -> /general/optophysiology/Zstack0033_green
+/acquisition/ROI_038_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x16830464"
 /acquisition/ROI_038_Green/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_038_Red
@@ -1140,6 +1215,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_038_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_038_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_038_Red/imaging_plane -> /general/optophysiology/Zstack0033_red
+/acquisition/ROI_038_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x16830464"
 /acquisition/ROI_038_Red/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_039_Green
@@ -1155,6 +1231,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_039_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_039_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_039_Green/imaging_plane -> /general/optophysiology/Zstack0033_green
+/acquisition/ROI_039_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x10bc03b1"
 /acquisition/ROI_039_Green/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_039_Red
@@ -1170,6 +1247,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_039_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_039_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_039_Red/imaging_plane -> /general/optophysiology/Zstack0033_red
+/acquisition/ROI_039_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x10bc03b1"
 /acquisition/ROI_039_Red/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_040_Green
@@ -1185,6 +1263,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_040_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_040_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_040_Green/imaging_plane -> /general/optophysiology/Zstack0033_green
+/acquisition/ROI_040_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x18e104fb"
 /acquisition/ROI_040_Green/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_040_Red
@@ -1200,6 +1279,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_040_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_040_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_040_Red/imaging_plane -> /general/optophysiology/Zstack0033_red
+/acquisition/ROI_040_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x18e104fb"
 /acquisition/ROI_040_Red/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_041_Green
@@ -1215,6 +1295,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_041_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_041_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_041_Green/imaging_plane -> /general/optophysiology/Zstack0033_green
+/acquisition/ROI_041_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xe1e0349"
 /acquisition/ROI_041_Green/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_041_Red
@@ -1230,6 +1311,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_041_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_041_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_041_Red/imaging_plane -> /general/optophysiology/Zstack0033_red
+/acquisition/ROI_041_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xe1e0349"
 /acquisition/ROI_041_Red/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_042_Green
@@ -1245,6 +1327,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_042_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_042_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_042_Green/imaging_plane -> /general/optophysiology/Zstack0033_green
+/acquisition/ROI_042_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x11470394"
 /acquisition/ROI_042_Green/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_042_Red
@@ -1260,6 +1343,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_042_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_042_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_042_Red/imaging_plane -> /general/optophysiology/Zstack0033_red
+/acquisition/ROI_042_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x11470394"
 /acquisition/ROI_042_Red/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_043_Green
@@ -1275,6 +1359,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_043_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_043_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_043_Green/imaging_plane -> /general/optophysiology/Zstack0033_green
+/acquisition/ROI_043_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x187504df"
 /acquisition/ROI_043_Green/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_043_Red
@@ -1290,6 +1375,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_043_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_043_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_043_Red/imaging_plane -> /general/optophysiology/Zstack0033_red
+/acquisition/ROI_043_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x187504df"
 /acquisition/ROI_043_Red/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_044_Green
@@ -1305,6 +1391,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_044_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_044_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_044_Green/imaging_plane -> /general/optophysiology/Zstack0033_green
+/acquisition/ROI_044_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xdaa032c"
 /acquisition/ROI_044_Green/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_044_Red
@@ -1320,6 +1407,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_044_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_044_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_044_Red/imaging_plane -> /general/optophysiology/Zstack0033_red
+/acquisition/ROI_044_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xdaa032c"
 /acquisition/ROI_044_Red/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_045_Green
@@ -1335,6 +1423,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_045_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_045_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_045_Green/imaging_plane -> /general/optophysiology/Zstack0034_green
+/acquisition/ROI_045_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xfdc0378"
 /acquisition/ROI_045_Green/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_045_Red
@@ -1350,6 +1439,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_045_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_045_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_045_Red/imaging_plane -> /general/optophysiology/Zstack0034_red
+/acquisition/ROI_045_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xfdc0378"
 /acquisition/ROI_045_Red/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_046_Green
@@ -1365,6 +1455,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_046_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_046_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_046_Green/imaging_plane -> /general/optophysiology/Zstack0034_green
+/acquisition/ROI_046_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xe0902c4"
 /acquisition/ROI_046_Green/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_046_Red
@@ -1380,6 +1471,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_046_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_046_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_046_Red/imaging_plane -> /general/optophysiology/Zstack0034_red
+/acquisition/ROI_046_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xe0902c4"
 /acquisition/ROI_046_Red/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_047_Green
@@ -1395,6 +1487,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_047_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_047_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_047_Green/imaging_plane -> /general/optophysiology/Zstack0034_green
+/acquisition/ROI_047_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x1438040f"
 /acquisition/ROI_047_Green/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_047_Red
@@ -1410,6 +1503,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_047_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_047_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_047_Red/imaging_plane -> /general/optophysiology/Zstack0034_red
+/acquisition/ROI_047_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x1438040f"
 /acquisition/ROI_047_Red/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_048_Green
@@ -1425,6 +1519,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_048_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_048_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_048_Green/imaging_plane -> /general/optophysiology/Zstack0034_green
+/acquisition/ROI_048_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xb73025d"
 /acquisition/ROI_048_Green/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_048_Red
@@ -1440,6 +1535,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_048_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_048_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_048_Red/imaging_plane -> /general/optophysiology/Zstack0034_red
+/acquisition/ROI_048_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xb73025d"
 /acquisition/ROI_048_Red/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_049_Green
@@ -1455,6 +1551,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_049_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_049_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_049_Green/imaging_plane -> /general/optophysiology/Zstack0035_green
+/acquisition/ROI_049_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x109b03a7"
 /acquisition/ROI_049_Green/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_049_Red
@@ -1470,6 +1567,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_049_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_049_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_049_Red/imaging_plane -> /general/optophysiology/Zstack0035_red
+/acquisition/ROI_049_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x109b03a7"
 /acquisition/ROI_049_Red/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_050_Green
@@ -1485,6 +1583,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_050_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_050_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_050_Green/imaging_plane -> /general/optophysiology/Zstack0032_green
+/acquisition/ROI_050_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xfcf02f4"
 /acquisition/ROI_050_Green/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_050_Red
@@ -1500,6 +1599,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_050_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_050_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_050_Red/imaging_plane -> /general/optophysiology/Zstack0032_red
+/acquisition/ROI_050_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xfcf02f4"
 /acquisition/ROI_050_Red/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_051_Green
@@ -1515,6 +1615,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_051_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_051_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_051_Green/imaging_plane -> /general/optophysiology/Zstack0032_green
+/acquisition/ROI_051_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x1af2053d"
 /acquisition/ROI_051_Green/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_051_Red
@@ -1530,6 +1631,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_051_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_051_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_051_Red/imaging_plane -> /general/optophysiology/Zstack0032_red
+/acquisition/ROI_051_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x1af2053d"
 /acquisition/ROI_051_Red/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_052_Green
@@ -1545,6 +1647,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_052_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_052_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_052_Green/imaging_plane -> /general/optophysiology/Zstack0033_green
+/acquisition/ROI_052_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xc32028c"
 /acquisition/ROI_052_Green/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_052_Red
@@ -1560,6 +1663,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_052_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_052_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_052_Red/imaging_plane -> /general/optophysiology/Zstack0033_red
+/acquisition/ROI_052_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xc32028c"
 /acquisition/ROI_052_Red/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_053_Green
@@ -1575,6 +1679,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_053_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_053_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_053_Green/imaging_plane -> /general/optophysiology/Zstack0033_green
+/acquisition/ROI_053_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x125903d6"
 /acquisition/ROI_053_Green/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_053_Red
@@ -1590,6 +1695,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_053_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_053_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_053_Red/imaging_plane -> /general/optophysiology/Zstack0033_red
+/acquisition/ROI_053_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x125903d6"
 /acquisition/ROI_053_Red/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_054_Green
@@ -1605,6 +1711,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_054_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_054_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_054_Green/imaging_plane -> /general/optophysiology/Zstack0033_green
+/acquisition/ROI_054_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x19870521"
 /acquisition/ROI_054_Green/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_054_Red
@@ -1620,6 +1727,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_054_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_054_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_054_Red/imaging_plane -> /general/optophysiology/Zstack0033_red
+/acquisition/ROI_054_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x19870521"
 /acquisition/ROI_054_Red/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_055_Green
@@ -1635,6 +1743,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_055_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_055_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_055_Green/imaging_plane -> /general/optophysiology/Zstack0033_green
+/acquisition/ROI_055_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x16b5046d"
 /acquisition/ROI_055_Green/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_055_Red
@@ -1650,6 +1759,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_055_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_055_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_055_Red/imaging_plane -> /general/optophysiology/Zstack0033_red
+/acquisition/ROI_055_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x16b5046d"
 /acquisition/ROI_055_Red/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_056_Green
@@ -1665,6 +1775,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_056_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_056_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_056_Green/imaging_plane -> /general/optophysiology/Zstack0034_green
+/acquisition/ROI_056_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x9f402bb"
 /acquisition/ROI_056_Green/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_056_Red
@@ -1680,6 +1791,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_056_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_056_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_056_Red/imaging_plane -> /general/optophysiology/Zstack0034_red
+/acquisition/ROI_056_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x9f402bb"
 /acquisition/ROI_056_Red/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_057_Green
@@ -1695,6 +1807,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_057_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_057_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_057_Green/imaging_plane -> /general/optophysiology/Zstack0034_green
+/acquisition/ROI_057_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x12210406"
 /acquisition/ROI_057_Green/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_057_Red
@@ -1710,6 +1823,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_057_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_057_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_057_Red/imaging_plane -> /general/optophysiology/Zstack0034_red
+/acquisition/ROI_057_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x12210406"
 /acquisition/ROI_057_Red/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_058_Green
@@ -1725,6 +1839,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_058_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_058_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_058_Green/imaging_plane -> /general/optophysiology/Zstack0034_green
+/acquisition/ROI_058_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xe500352"
 /acquisition/ROI_058_Green/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_058_Red
@@ -1740,6 +1855,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_058_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_058_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_058_Red/imaging_plane -> /general/optophysiology/Zstack0034_red
+/acquisition/ROI_058_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xe500352"
 /acquisition/ROI_058_Red/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_059_Green
@@ -1755,6 +1871,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_059_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_059_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_059_Green/imaging_plane -> /general/optophysiology/Zstack0034_green
+/acquisition/ROI_059_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x103e031e"
 /acquisition/ROI_059_Green/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_059_Red
@@ -1770,6 +1887,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_059_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_059_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_059_Red/imaging_plane -> /general/optophysiology/Zstack0034_red
+/acquisition/ROI_059_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x103e031e"
 /acquisition/ROI_059_Red/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_060_Green
@@ -1785,6 +1903,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_060_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_060_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_060_Green/imaging_plane -> /general/optophysiology/Zstack0034_green
+/acquisition/ROI_060_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x19cc04c2"
 /acquisition/ROI_060_Green/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_060_Red
@@ -1800,6 +1919,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_060_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_060_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_060_Red/imaging_plane -> /general/optophysiology/Zstack0034_red
+/acquisition/ROI_060_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x19cc04c2"
 /acquisition/ROI_060_Red/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_061_Green
@@ -1815,6 +1935,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_061_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_061_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_061_Green/imaging_plane -> /general/optophysiology/Zstack0034_green
+/acquisition/ROI_061_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x15520402"
 /acquisition/ROI_061_Green/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_061_Red
@@ -1830,6 +1951,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_061_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_061_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_061_Red/imaging_plane -> /general/optophysiology/Zstack0034_red
+/acquisition/ROI_061_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x15520402"
 /acquisition/ROI_061_Red/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_062_Green
@@ -1845,6 +1967,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_062_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_062_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_062_Green/imaging_plane -> /general/optophysiology/Zstack0034_green
+/acquisition/ROI_062_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x12ea03a8"
 /acquisition/ROI_062_Green/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_062_Red
@@ -1860,6 +1983,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_062_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_062_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_062_Red/imaging_plane -> /general/optophysiology/Zstack0034_red
+/acquisition/ROI_062_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x12ea03a8"
 /acquisition/ROI_062_Red/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_063_Green
@@ -1875,6 +1999,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_063_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_063_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_063_Green/imaging_plane -> /general/optophysiology/Zstack0035_green
+/acquisition/ROI_063_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x177c044d"
 /acquisition/ROI_063_Green/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_063_Red
@@ -1890,6 +2015,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_063_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_063_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_063_Red/imaging_plane -> /general/optophysiology/Zstack0035_red
+/acquisition/ROI_063_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x177c044d"
 /acquisition/ROI_063_Red/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_064_Green
@@ -1905,6 +2031,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_064_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_064_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_064_Green/imaging_plane -> /general/optophysiology/Zstack0035_green
+/acquisition/ROI_064_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xd2302f5"
 /acquisition/ROI_064_Green/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_064_Red
@@ -1920,6 +2047,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_064_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_064_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_064_Red/imaging_plane -> /general/optophysiology/Zstack0035_red
+/acquisition/ROI_064_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xd2302f5"
 /acquisition/ROI_064_Red/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_065_Green
@@ -1935,6 +2063,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_065_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_065_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_065_Green/imaging_plane -> /general/optophysiology/Zstack0035_green
+/acquisition/ROI_065_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x14b30499"
 /acquisition/ROI_065_Green/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_065_Red
@@ -1950,6 +2079,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_065_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_065_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_065_Red/imaging_plane -> /general/optophysiology/Zstack0035_red
+/acquisition/ROI_065_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x14b30499"
 /acquisition/ROI_065_Red/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_066_Green
@@ -1965,6 +2095,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_066_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_066_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_066_Green/imaging_plane -> /general/optophysiology/Zstack0035_green
+/acquisition/ROI_066_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xf4d0340"
 /acquisition/ROI_066_Green/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_066_Red
@@ -1980,6 +2111,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_066_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_066_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_066_Red/imaging_plane -> /general/optophysiology/Zstack0035_red
+/acquisition/ROI_066_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xf4d0340"
 /acquisition/ROI_066_Red/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_067_Green
@@ -1995,6 +2127,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_067_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_067_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_067_Green/imaging_plane -> /general/optophysiology/Zstack0035_green
+/acquisition/ROI_067_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xce502e6"
 /acquisition/ROI_067_Green/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_067_Red
@@ -2010,6 +2143,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_067_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_067_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_067_Red/imaging_plane -> /general/optophysiology/Zstack0035_red
+/acquisition/ROI_067_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xce502e6"
 /acquisition/ROI_067_Red/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_068_Green
@@ -2025,6 +2159,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_068_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_068_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_068_Green/imaging_plane -> /general/optophysiology/Zstack0035_green
+/acquisition/ROI_068_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x117f038c"
 /acquisition/ROI_068_Green/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_068_Red
@@ -2040,6 +2175,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_068_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_068_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_068_Red/imaging_plane -> /general/optophysiology/Zstack0035_red
+/acquisition/ROI_068_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x117f038c"
 /acquisition/ROI_068_Red/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_069_Green
@@ -2055,6 +2191,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_069_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_069_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_069_Green/imaging_plane -> /general/optophysiology/Zstack0035_green
+/acquisition/ROI_069_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x13140431"
 /acquisition/ROI_069_Green/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_069_Red
@@ -2070,6 +2207,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_069_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_069_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_069_Red/imaging_plane -> /general/optophysiology/Zstack0035_red
+/acquisition/ROI_069_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x13140431"
 /acquisition/ROI_069_Red/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_070_Green
@@ -2085,6 +2223,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_070_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_070_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_070_Green/imaging_plane -> /general/optophysiology/Zstack0040_green
+/acquisition/ROI_070_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x14a803d7"
 /acquisition/ROI_070_Green/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_070_Red
@@ -2100,6 +2239,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_070_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_070_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_070_Red/imaging_plane -> /general/optophysiology/Zstack0040_red
+/acquisition/ROI_070_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x14a803d7"
 /acquisition/ROI_070_Red/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_071_Green
@@ -2115,6 +2255,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_071_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_071_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_071_Green/imaging_plane -> /general/optophysiology/Zstack0040_green
+/acquisition/ROI_071_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x1141037d"
 /acquisition/ROI_071_Green/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_071_Red
@@ -2130,6 +2271,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_071_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_071_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_071_Red/imaging_plane -> /general/optophysiology/Zstack0040_red
+/acquisition/ROI_071_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x1141037d"
 /acquisition/ROI_071_Red/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_072_Green
@@ -2145,6 +2287,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_072_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_072_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_072_Green/imaging_plane -> /general/optophysiology/Zstack0040_green
+/acquisition/ROI_072_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xde20324"
 /acquisition/ROI_072_Green/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_072_Red
@@ -2160,6 +2303,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_072_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_072_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_072_Red/imaging_plane -> /general/optophysiology/Zstack0040_red
+/acquisition/ROI_072_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xde20324"
 /acquisition/ROI_072_Red/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_073_Green
@@ -2175,6 +2319,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_073_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_073_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_073_Green/imaging_plane -> /general/optophysiology/Zstack0040_green
+/acquisition/ROI_073_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xf7703c9"
 /acquisition/ROI_073_Green/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_073_Red
@@ -2190,6 +2335,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_073_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_073_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_073_Red/imaging_plane -> /general/optophysiology/Zstack0040_red
+/acquisition/ROI_073_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xf7703c9"
 /acquisition/ROI_073_Red/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_074_Green
@@ -2205,6 +2351,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_074_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_074_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_074_Green/imaging_plane -> /general/optophysiology/Zstack0039_green
+/acquisition/ROI_074_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x110b036f"
 /acquisition/ROI_074_Green/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_074_Red
@@ -2220,6 +2367,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_074_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_074_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_074_Red/imaging_plane -> /general/optophysiology/Zstack0039_red
+/acquisition/ROI_074_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x110b036f"
 /acquisition/ROI_074_Red/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_075_Green
@@ -2235,6 +2383,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_075_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_075_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_075_Green/imaging_plane -> /general/optophysiology/Zstack0039_green
+/acquisition/ROI_075_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xeab0316"
 /acquisition/ROI_075_Green/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_075_Red
@@ -2250,6 +2399,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_075_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_075_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_075_Red/imaging_plane -> /general/optophysiology/Zstack0039_red
+/acquisition/ROI_075_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xeab0316"
 /acquisition/ROI_075_Red/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_076_Green
@@ -2265,6 +2415,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_076_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_076_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_076_Green/imaging_plane -> /general/optophysiology/Zstack0046_green
+/acquisition/ROI_076_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x123e03bb"
 /acquisition/ROI_076_Green/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_076_Red
@@ -2280,6 +2431,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_076_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_076_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_076_Red/imaging_plane -> /general/optophysiology/Zstack0046_red
+/acquisition/ROI_076_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x123e03bb"
 /acquisition/ROI_076_Red/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_077_Green
@@ -2295,6 +2447,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_077_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_077_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_077_Green/imaging_plane -> /general/optophysiology/Zstack0046_green
+/acquisition/ROI_077_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xfd60361"
 /acquisition/ROI_077_Green/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_077_Red
@@ -2310,6 +2463,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_077_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_077_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_077_Red/imaging_plane -> /general/optophysiology/Zstack0046_red
+/acquisition/ROI_077_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xfd60361"
 /acquisition/ROI_077_Red/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_078_Green
@@ -2325,6 +2479,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_078_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_078_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_078_Green/imaging_plane -> /general/optophysiology/Zstack0033_green
+/acquisition/ROI_078_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x15670406"
 /acquisition/ROI_078_Green/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_078_Red
@@ -2340,6 +2495,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_078_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_078_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_078_Red/imaging_plane -> /general/optophysiology/Zstack0033_red
+/acquisition/ROI_078_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x15670406"
 /acquisition/ROI_078_Red/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_079_Green
@@ -2355,6 +2511,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_079_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_079_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_079_Green/imaging_plane -> /general/optophysiology/Zstack0022_green
+/acquisition/ROI_079_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x130703ad"
 /acquisition/ROI_079_Green/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_079_Red
@@ -2370,6 +2527,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_079_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_079_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_079_Red/imaging_plane -> /general/optophysiology/Zstack0022_red
+/acquisition/ROI_079_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x130703ad"
 /acquisition/ROI_079_Red/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_080_Green
@@ -2385,6 +2543,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_080_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_080_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_080_Green/imaging_plane -> /general/optophysiology/Zstack0022_green
+/acquisition/ROI_080_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x17990452"
 /acquisition/ROI_080_Green/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/ROI_080_Red
@@ -2400,6 +2559,7 @@ Generating signature for 161215_15_58_52.nwb
 /acquisition/ROI_080_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_080_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_080_Red/imaging_plane -> /general/optophysiology/Zstack0022_red
+/acquisition/ROI_080_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x17990452"
 /acquisition/ROI_080_Red/timestamps: dtype=float64 shape=(175440,) val="0xf51904ca"
 	@unit: type=str val="seconds"
 /acquisition/Zstack_Green_0001
@@ -5072,6 +5232,7 @@ Generating signature for 161215_15_58_52.nwb
 /general/optophysiology/Zstack0049_red/reference_frame: dtype=object shape=() val="TODO: In lab book (partly?)"
 /general/session_id: dtype=object shape=() val="161215_15_58_52"
 /general/silverlab_metadata
+	@labview_version: type=str val="pre-2018 (original)"
 	@silverlab_api_version: type=str val="0.2"
 /general/silverlab_optophysiology
 	@cycle_time: dtype=float64 shape=() val="0.00287185"
@@ -5106,7 +5267,7 @@ Generating signature for 161215_15_58_52.nwb
 /processing/Acquired_ROIs
 	@description: type=str val="ROI locations and acquired fluorescence readings made directly by the AOL microscope."
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0022_green
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0022_green/angle_deg: dtype=float64 shape=(2,) val="0x100001"
 	@description: type=str val="Angle (deg)"
@@ -5128,8 +5289,6 @@ Generating signature for 161215_15_58_52.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0022_green/pixel_mask_index: dtype=int64 shape=(2,) val="0x300004"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0022_green/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0022_green/pixel_time_offsets: dtype=float64 shape=(2, 1) val="0x480007fe"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0022_green/reference_images/Zstack_Red_0022 -> /acquisition/Zstack_Red_0022
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0022_green/reference_images/reference_images -> /acquisition/Zstack_Red_0022
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0022_green/roi_group_id: dtype=float64 shape=(2,) val="0x100001"
@@ -5153,7 +5312,7 @@ Generating signature for 161215_15_58_52.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0022_green/zoom: dtype=float64 shape=(2,) val="0xdc6025f"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0022_red
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0022_red/angle_deg: dtype=float64 shape=(2,) val="0x100001"
 	@description: type=str val="Angle (deg)"
@@ -5175,8 +5334,6 @@ Generating signature for 161215_15_58_52.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0022_red/pixel_mask_index: dtype=int64 shape=(2,) val="0x300004"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0022_red/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0022_red/pixel_time_offsets: dtype=float64 shape=(2, 1) val="0x480007fe"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0022_red/reference_images/Zstack_Red_0022 -> /acquisition/Zstack_Red_0022
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0022_red/reference_images/reference_images -> /acquisition/Zstack_Red_0022
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0022_red/roi_group_id: dtype=float64 shape=(2,) val="0x100001"
@@ -5200,7 +5357,7 @@ Generating signature for 161215_15_58_52.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0022_red/zoom: dtype=float64 shape=(2,) val="0xdc6025f"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0025_green
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0025_green/angle_deg: dtype=float64 shape=(2,) val="0x100001"
 	@description: type=str val="Angle (deg)"
@@ -5222,8 +5379,6 @@ Generating signature for 161215_15_58_52.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0025_green/pixel_mask_index: dtype=int64 shape=(2,) val="0x300004"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0025_green/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0025_green/pixel_time_offsets: dtype=float64 shape=(2, 1) val="0x34280670"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0025_green/reference_images/Zstack_Red_0025 -> /acquisition/Zstack_Red_0025
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0025_green/reference_images/reference_images -> /acquisition/Zstack_Red_0025
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0025_green/roi_group_id: dtype=float64 shape=(2,) val="0x100001"
@@ -5247,7 +5402,7 @@ Generating signature for 161215_15_58_52.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0025_green/zoom: dtype=float64 shape=(2,) val="0xdc6025f"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0025_red
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0025_red/angle_deg: dtype=float64 shape=(2,) val="0x100001"
 	@description: type=str val="Angle (deg)"
@@ -5269,8 +5424,6 @@ Generating signature for 161215_15_58_52.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0025_red/pixel_mask_index: dtype=int64 shape=(2,) val="0x300004"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0025_red/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0025_red/pixel_time_offsets: dtype=float64 shape=(2, 1) val="0x34280670"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0025_red/reference_images/Zstack_Red_0025 -> /acquisition/Zstack_Red_0025
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0025_red/reference_images/reference_images -> /acquisition/Zstack_Red_0025
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0025_red/roi_group_id: dtype=float64 shape=(2,) val="0x100001"
@@ -5294,7 +5447,7 @@ Generating signature for 161215_15_58_52.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0025_red/zoom: dtype=float64 shape=(2,) val="0xdc6025f"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0028_green
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0028_green/angle_deg: dtype=float64 shape=(5,) val="0x280001"
 	@description: type=str val="Angle (deg)"
@@ -5316,8 +5469,6 @@ Generating signature for 161215_15_58_52.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0028_green/pixel_mask_index: dtype=int64 shape=(5,) val="0x1400010"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0028_green/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0028_green/pixel_time_offsets: dtype=float64 shape=(5, 1) val="0x530c1127"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0028_green/reference_images/Zstack_Red_0028 -> /acquisition/Zstack_Red_0028
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0028_green/reference_images/reference_images -> /acquisition/Zstack_Red_0028
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0028_green/roi_group_id: dtype=float64 shape=(5,) val="0x280001"
@@ -5341,7 +5492,7 @@ Generating signature for 161215_15_58_52.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0028_green/zoom: dtype=float64 shape=(5,) val="0x697305ec"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0028_red
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0028_red/angle_deg: dtype=float64 shape=(5,) val="0x280001"
 	@description: type=str val="Angle (deg)"
@@ -5363,8 +5514,6 @@ Generating signature for 161215_15_58_52.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0028_red/pixel_mask_index: dtype=int64 shape=(5,) val="0x1400010"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0028_red/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0028_red/pixel_time_offsets: dtype=float64 shape=(5, 1) val="0x530c1127"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0028_red/reference_images/Zstack_Red_0028 -> /acquisition/Zstack_Red_0028
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0028_red/reference_images/reference_images -> /acquisition/Zstack_Red_0028
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0028_red/roi_group_id: dtype=float64 shape=(5,) val="0x280001"
@@ -5388,7 +5537,7 @@ Generating signature for 161215_15_58_52.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0028_red/zoom: dtype=float64 shape=(5,) val="0x697305ec"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0029_green
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0029_green/angle_deg: dtype=float64 shape=(6,) val="0x300001"
 	@description: type=str val="Angle (deg)"
@@ -5410,8 +5559,6 @@ Generating signature for 161215_15_58_52.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0029_green/pixel_mask_index: dtype=int64 shape=(6,) val="0x1f00016"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0029_green/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0029_green/pixel_time_offsets: dtype=float64 shape=(6, 1) val="0x26921567"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0029_green/reference_images/Zstack_Red_0029 -> /acquisition/Zstack_Red_0029
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0029_green/reference_images/reference_images -> /acquisition/Zstack_Red_0029
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0029_green/roi_group_id: dtype=float64 shape=(6,) val="0x300001"
@@ -5435,7 +5582,7 @@ Generating signature for 161215_15_58_52.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0029_green/zoom: dtype=float64 shape=(6,) val="0x9af2071b"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0029_red
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0029_red/angle_deg: dtype=float64 shape=(6,) val="0x300001"
 	@description: type=str val="Angle (deg)"
@@ -5457,8 +5604,6 @@ Generating signature for 161215_15_58_52.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0029_red/pixel_mask_index: dtype=int64 shape=(6,) val="0x1f00016"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0029_red/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0029_red/pixel_time_offsets: dtype=float64 shape=(6, 1) val="0x26921567"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0029_red/reference_images/Zstack_Red_0029 -> /acquisition/Zstack_Red_0029
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0029_red/reference_images/reference_images -> /acquisition/Zstack_Red_0029
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0029_red/roi_group_id: dtype=float64 shape=(6,) val="0x300001"
@@ -5482,7 +5627,7 @@ Generating signature for 161215_15_58_52.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0029_red/zoom: dtype=float64 shape=(6,) val="0x9af2071b"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0032_green
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0032_green/angle_deg: dtype=float64 shape=(2,) val="0x100001"
 	@description: type=str val="Angle (deg)"
@@ -5504,8 +5649,6 @@ Generating signature for 161215_15_58_52.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0032_green/pixel_mask_index: dtype=int64 shape=(2,) val="0x300004"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0032_green/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0032_green/pixel_time_offsets: dtype=float64 shape=(2, 1) val="0x42590830"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0032_green/reference_images/Zstack_Red_0032 -> /acquisition/Zstack_Red_0032
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0032_green/reference_images/reference_images -> /acquisition/Zstack_Red_0032
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0032_green/roi_group_id: dtype=float64 shape=(2,) val="0x100001"
@@ -5529,7 +5672,7 @@ Generating signature for 161215_15_58_52.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0032_green/zoom: dtype=float64 shape=(2,) val="0xdc6025f"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0032_red
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0032_red/angle_deg: dtype=float64 shape=(2,) val="0x100001"
 	@description: type=str val="Angle (deg)"
@@ -5551,8 +5694,6 @@ Generating signature for 161215_15_58_52.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0032_red/pixel_mask_index: dtype=int64 shape=(2,) val="0x300004"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0032_red/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0032_red/pixel_time_offsets: dtype=float64 shape=(2, 1) val="0x42590830"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0032_red/reference_images/Zstack_Red_0032 -> /acquisition/Zstack_Red_0032
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0032_red/reference_images/reference_images -> /acquisition/Zstack_Red_0032
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0032_red/roi_group_id: dtype=float64 shape=(2,) val="0x100001"
@@ -5576,7 +5717,7 @@ Generating signature for 161215_15_58_52.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0032_red/zoom: dtype=float64 shape=(2,) val="0xdc6025f"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0033_green
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0033_green/angle_deg: dtype=float64 shape=(20,) val="0xa00001"
 	@description: type=str val="Angle (deg)"
@@ -5598,8 +5739,6 @@ Generating signature for 161215_15_58_52.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0033_green/pixel_mask_index: dtype=int64 shape=(20,) val="0x30c000d3"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0033_green/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0033_green/pixel_time_offsets: dtype=float64 shape=(20, 1) val="0xf5044d30"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0033_green/reference_images/Zstack_Red_0033 -> /acquisition/Zstack_Red_0033
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0033_green/reference_images/reference_images -> /acquisition/Zstack_Red_0033
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0033_green/roi_group_id: dtype=float64 shape=(20,) val="0xa00001"
@@ -5623,7 +5762,7 @@ Generating signature for 161215_15_58_52.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0033_green/zoom: dtype=float64 shape=(20,) val="0x328517ad"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0033_red
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0033_red/angle_deg: dtype=float64 shape=(20,) val="0xa00001"
 	@description: type=str val="Angle (deg)"
@@ -5645,8 +5784,6 @@ Generating signature for 161215_15_58_52.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0033_red/pixel_mask_index: dtype=int64 shape=(20,) val="0x30c000d3"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0033_red/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0033_red/pixel_time_offsets: dtype=float64 shape=(20, 1) val="0xf5044d30"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0033_red/reference_images/Zstack_Red_0033 -> /acquisition/Zstack_Red_0033
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0033_red/reference_images/reference_images -> /acquisition/Zstack_Red_0033
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0033_red/roi_group_id: dtype=float64 shape=(20,) val="0xa00001"
@@ -5670,7 +5807,7 @@ Generating signature for 161215_15_58_52.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0033_red/zoom: dtype=float64 shape=(20,) val="0x328517ad"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0034_green
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0034_green/angle_deg: dtype=float64 shape=(21,) val="0xa80001"
 	@description: type=str val="Angle (deg)"
@@ -5692,8 +5829,6 @@ Generating signature for 161215_15_58_52.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0034_green/pixel_mask_index: dtype=int64 shape=(21,) val="0x380000e8"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0034_green/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0034_green/pixel_time_offsets: dtype=float64 shape=(21, 1) val="0x7951487a"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0034_green/reference_images/Zstack_Red_0034 -> /acquisition/Zstack_Red_0034
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0034_green/reference_images/reference_images -> /acquisition/Zstack_Red_0034
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0034_green/roi_group_id: dtype=float64 shape=(21,) val="0xa80001"
@@ -5717,7 +5852,7 @@ Generating signature for 161215_15_58_52.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0034_green/zoom: dtype=float64 shape=(21,) val="0xf20c18dc"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0034_red
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0034_red/angle_deg: dtype=float64 shape=(21,) val="0xa80001"
 	@description: type=str val="Angle (deg)"
@@ -5739,8 +5874,6 @@ Generating signature for 161215_15_58_52.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0034_red/pixel_mask_index: dtype=int64 shape=(21,) val="0x380000e8"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0034_red/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0034_red/pixel_time_offsets: dtype=float64 shape=(21, 1) val="0x7951487a"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0034_red/reference_images/Zstack_Red_0034 -> /acquisition/Zstack_Red_0034
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0034_red/reference_images/reference_images -> /acquisition/Zstack_Red_0034
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0034_red/roi_group_id: dtype=float64 shape=(21,) val="0xa80001"
@@ -5764,7 +5897,7 @@ Generating signature for 161215_15_58_52.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0034_red/zoom: dtype=float64 shape=(21,) val="0xf20c18dc"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0035_green
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0035_green/angle_deg: dtype=float64 shape=(14,) val="0x700001"
 	@description: type=str val="Angle (deg)"
@@ -5786,8 +5919,6 @@ Generating signature for 161215_15_58_52.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0035_green/pixel_mask_index: dtype=int64 shape=(14,) val="0x11f0006a"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0035_green/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0035_green/pixel_time_offsets: dtype=float64 shape=(14, 1) val="0x180a3299"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0035_green/reference_images/Zstack_Red_0035 -> /acquisition/Zstack_Red_0035
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0035_green/reference_images/reference_images -> /acquisition/Zstack_Red_0035
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0035_green/roi_group_id: dtype=float64 shape=(14,) val="0x700001"
@@ -5811,7 +5942,7 @@ Generating signature for 161215_15_58_52.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0035_green/zoom: dtype=float64 shape=(14,) val="0x7bf71093"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0035_red
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0035_red/angle_deg: dtype=float64 shape=(14,) val="0x700001"
 	@description: type=str val="Angle (deg)"
@@ -5833,8 +5964,6 @@ Generating signature for 161215_15_58_52.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0035_red/pixel_mask_index: dtype=int64 shape=(14,) val="0x11f0006a"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0035_red/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0035_red/pixel_time_offsets: dtype=float64 shape=(14, 1) val="0x180a3299"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0035_red/reference_images/Zstack_Red_0035 -> /acquisition/Zstack_Red_0035
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0035_red/reference_images/reference_images -> /acquisition/Zstack_Red_0035
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0035_red/roi_group_id: dtype=float64 shape=(14,) val="0x700001"
@@ -5858,7 +5987,7 @@ Generating signature for 161215_15_58_52.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0035_red/zoom: dtype=float64 shape=(14,) val="0x7bf71093"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0039_green
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0039_green/angle_deg: dtype=float64 shape=(2,) val="0x100001"
 	@description: type=str val="Angle (deg)"
@@ -5880,8 +6009,6 @@ Generating signature for 161215_15_58_52.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0039_green/pixel_mask_index: dtype=int64 shape=(2,) val="0x300004"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0039_green/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0039_green/pixel_time_offsets: dtype=float64 shape=(2, 1) val="0x3b260684"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0039_green/reference_images/Zstack_Red_0039 -> /acquisition/Zstack_Red_0039
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0039_green/reference_images/reference_images -> /acquisition/Zstack_Red_0039
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0039_green/roi_group_id: dtype=float64 shape=(2,) val="0x100001"
@@ -5905,7 +6032,7 @@ Generating signature for 161215_15_58_52.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0039_green/zoom: dtype=float64 shape=(2,) val="0xdc6025f"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0039_red
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0039_red/angle_deg: dtype=float64 shape=(2,) val="0x100001"
 	@description: type=str val="Angle (deg)"
@@ -5927,8 +6054,6 @@ Generating signature for 161215_15_58_52.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0039_red/pixel_mask_index: dtype=int64 shape=(2,) val="0x300004"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0039_red/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0039_red/pixel_time_offsets: dtype=float64 shape=(2, 1) val="0x3b260684"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0039_red/reference_images/Zstack_Red_0039 -> /acquisition/Zstack_Red_0039
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0039_red/reference_images/reference_images -> /acquisition/Zstack_Red_0039
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0039_red/roi_group_id: dtype=float64 shape=(2,) val="0x100001"
@@ -5952,7 +6077,7 @@ Generating signature for 161215_15_58_52.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0039_red/zoom: dtype=float64 shape=(2,) val="0xdc6025f"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0040_green
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0040_green/angle_deg: dtype=float64 shape=(4,) val="0x200001"
 	@description: type=str val="Angle (deg)"
@@ -5974,8 +6099,6 @@ Generating signature for 161215_15_58_52.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0040_green/pixel_mask_index: dtype=int64 shape=(4,) val="0xc0000b"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0040_green/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0040_green/pixel_time_offsets: dtype=float64 shape=(4, 1) val="0xf02a0e3e"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0040_green/reference_images/Zstack_Red_0040 -> /acquisition/Zstack_Red_0040
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0040_green/reference_images/reference_images -> /acquisition/Zstack_Red_0040
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0040_green/roi_group_id: dtype=float64 shape=(4,) val="0x200001"
@@ -5999,7 +6122,7 @@ Generating signature for 161215_15_58_52.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0040_green/zoom: dtype=float64 shape=(4,) val="0x416c04bd"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0040_red
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0040_red/angle_deg: dtype=float64 shape=(4,) val="0x200001"
 	@description: type=str val="Angle (deg)"
@@ -6021,8 +6144,6 @@ Generating signature for 161215_15_58_52.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0040_red/pixel_mask_index: dtype=int64 shape=(4,) val="0xc0000b"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0040_red/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0040_red/pixel_time_offsets: dtype=float64 shape=(4, 1) val="0xf02a0e3e"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0040_red/reference_images/Zstack_Red_0040 -> /acquisition/Zstack_Red_0040
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0040_red/reference_images/reference_images -> /acquisition/Zstack_Red_0040
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0040_red/roi_group_id: dtype=float64 shape=(4,) val="0x200001"
@@ -6046,7 +6167,7 @@ Generating signature for 161215_15_58_52.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0040_red/zoom: dtype=float64 shape=(4,) val="0x416c04bd"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0046_green
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0046_green/angle_deg: dtype=float64 shape=(2,) val="0x100001"
 	@description: type=str val="Angle (deg)"
@@ -6068,8 +6189,6 @@ Generating signature for 161215_15_58_52.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0046_green/pixel_mask_index: dtype=int64 shape=(2,) val="0x300004"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0046_green/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0046_green/pixel_time_offsets: dtype=float64 shape=(2, 1) val="0x3fe4071b"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0046_green/reference_images/Zstack_Red_0046 -> /acquisition/Zstack_Red_0046
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0046_green/reference_images/reference_images -> /acquisition/Zstack_Red_0046
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0046_green/roi_group_id: dtype=float64 shape=(2,) val="0x100001"
@@ -6093,7 +6212,7 @@ Generating signature for 161215_15_58_52.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0046_green/zoom: dtype=float64 shape=(2,) val="0xdc6025f"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0046_red
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0046_red/angle_deg: dtype=float64 shape=(2,) val="0x100001"
 	@description: type=str val="Angle (deg)"
@@ -6115,8 +6234,6 @@ Generating signature for 161215_15_58_52.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0046_red/pixel_mask_index: dtype=int64 shape=(2,) val="0x300004"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0046_red/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0046_red/pixel_time_offsets: dtype=float64 shape=(2, 1) val="0x3fe4071b"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0046_red/reference_images/Zstack_Red_0046 -> /acquisition/Zstack_Red_0046
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0046_red/reference_images/reference_images -> /acquisition/Zstack_Red_0046
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0046_red/roi_group_id: dtype=float64 shape=(2,) val="0x100001"
@@ -6141,9 +6258,10 @@ Generating signature for 161215_15_58_52.nwb
 	@description: type=str val="Zoom"
 /session_description: dtype=object shape=() val="One or two sentences descri...0x65b618d5"
 /session_start_time: dtype=object shape=() val="2016-12-15T16:03:24.978909+...0x6b720682"
-/specifications/silverlab_extended_schema/0.2/namespace: dtype=object shape=() val="{"namespaces":[{"doc":"Exte...0x5f6a6a92"
-/specifications/silverlab_extended_schema/0.2/silverlab.metadata: dtype=object shape=() val="{"groups":[{"doc":"A place ...0xc0d670ae"
-/specifications/silverlab_extended_schema/0.2/silverlab.ophys: dtype=object shape=() val="{"groups":[{"datasets":[{"s...0xeab28ad7"
+/specifications/silverlab_extended_schema/0.3/namespace: dtype=object shape=() val="{"namespaces":[{"doc":"Exte...0x2db67446"
+/specifications/silverlab_extended_schema/0.3/silverlab.metadata: dtype=object shape=() val="{"groups":[{"doc":"A place ...0x908295e2"
+/specifications/silverlab_extended_schema/0.3/silverlab.ophys: dtype=object shape=() val="{"groups":[{"datasets":[{"s...0xeab28ad7"
+/specifications/silverlab_extended_schema/0.3/silverlab.roi: dtype=object shape=() val="{"groups":[{"datasets":[{"s...0x5c700123"
 /stimulus/presentation/air_puff
 	@comments: type=str val="Delivered 'instantaneously' at the specified times"
 	@description: type=str val="Air puff stimulus"

--- a/tests/data/161222_16_18_47.sig2
+++ b/tests/data/161222_16_18_47.sig2
@@ -5,7 +5,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/BodyCam
 	@comments: type=str val="Frame rate 90 fps"
 	@description: type=str val="Video recording of mouse behaviour."
-/acquisition/BodyCam/dimension: dtype=int32 shape=(2,) val="0x7990164"
+/acquisition/BodyCam/dimension: dtype=int64 shape=(2,) val="0xf350164"
 /acquisition/BodyCam/external_file: dtype=ignored shape=ignored val="ignored"
 	@starting_frame: dtype=int64 shape=(1,) val="0x80001"
 /acquisition/BodyCam/format: dtype=object shape=() val="external"
@@ -33,6 +33,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_001_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_001_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_001_Green/imaging_plane -> /general/optophysiology/Zstack0025_green
+/acquisition/ROI_001_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x159a045b"
 /acquisition/ROI_001_Green/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_001_Red
@@ -48,6 +49,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_001_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_001_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_001_Red/imaging_plane -> /general/optophysiology/Zstack0025_red
+/acquisition/ROI_001_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x159a045b"
 /acquisition/ROI_001_Red/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_002_Green
@@ -63,6 +65,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_002_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_002_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_002_Green/imaging_plane -> /general/optophysiology/Zstack0026_green
+/acquisition/ROI_002_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x115d038b"
 /acquisition/ROI_002_Green/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_002_Red
@@ -78,6 +81,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_002_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_002_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_002_Red/imaging_plane -> /general/optophysiology/Zstack0026_red
+/acquisition/ROI_002_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x115d038b"
 /acquisition/ROI_002_Red/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_003_Green
@@ -93,6 +97,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_003_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_003_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_003_Green/imaging_plane -> /general/optophysiology/Zstack0026_green
+/acquisition/ROI_003_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x181f04ba"
 /acquisition/ROI_003_Green/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_003_Red
@@ -108,6 +113,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_003_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_003_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_003_Red/imaging_plane -> /general/optophysiology/Zstack0026_red
+/acquisition/ROI_003_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x181f04ba"
 /acquisition/ROI_003_Red/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_004_Green
@@ -123,6 +129,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_004_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_004_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_004_Green/imaging_plane -> /general/optophysiology/Zstack0026_green
+/acquisition/ROI_004_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xce802eb"
 /acquisition/ROI_004_Green/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_004_Red
@@ -138,6 +145,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_004_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_004_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_004_Red/imaging_plane -> /general/optophysiology/Zstack0026_red
+/acquisition/ROI_004_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xce802eb"
 /acquisition/ROI_004_Red/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_005_Green
@@ -153,6 +161,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_005_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_005_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_005_Green/imaging_plane -> /general/optophysiology/Zstack0026_green
+/acquisition/ROI_005_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xfa5031a"
 /acquisition/ROI_005_Green/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_005_Red
@@ -168,6 +177,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_005_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_005_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_005_Red/imaging_plane -> /general/optophysiology/Zstack0026_red
+/acquisition/ROI_005_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xfa5031a"
 /acquisition/ROI_005_Red/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_006_Green
@@ -183,6 +193,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_006_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_006_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_006_Green/imaging_plane -> /general/optophysiology/Zstack0026_green
+/acquisition/ROI_006_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x11630349"
 /acquisition/ROI_006_Green/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_006_Red
@@ -198,6 +209,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_006_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_006_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_006_Red/imaging_plane -> /general/optophysiology/Zstack0026_red
+/acquisition/ROI_006_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x11630349"
 /acquisition/ROI_006_Red/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_007_Green
@@ -213,6 +225,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_007_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_007_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_007_Green/imaging_plane -> /general/optophysiology/Zstack0027_green
+/acquisition/ROI_007_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x8f501fc"
 /acquisition/ROI_007_Green/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_007_Red
@@ -228,6 +241,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_007_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_007_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_007_Red/imaging_plane -> /general/optophysiology/Zstack0027_red
+/acquisition/ROI_007_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x8f501fc"
 /acquisition/ROI_007_Red/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_008_Green
@@ -243,6 +257,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_008_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_008_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_008_Green/imaging_plane -> /general/optophysiology/Zstack0027_green
+/acquisition/ROI_008_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x16520492"
 /acquisition/ROI_008_Green/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_008_Red
@@ -258,6 +273,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_008_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_008_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_008_Red/imaging_plane -> /general/optophysiology/Zstack0027_red
+/acquisition/ROI_008_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x16520492"
 /acquisition/ROI_008_Red/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_009_Green
@@ -273,6 +289,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_009_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_009_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_009_Green/imaging_plane -> /general/optophysiology/Zstack0027_green
+/acquisition/ROI_009_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x12b5042a"
 /acquisition/ROI_009_Green/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_009_Red
@@ -288,6 +305,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_009_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_009_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_009_Red/imaging_plane -> /general/optophysiology/Zstack0027_red
+/acquisition/ROI_009_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x12b5042a"
 /acquisition/ROI_009_Red/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_010_Green
@@ -303,6 +321,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_010_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_010_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_010_Green/imaging_plane -> /general/optophysiology/Zstack0027_green
+/acquisition/ROI_010_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x171104c1"
 /acquisition/ROI_010_Green/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_010_Red
@@ -318,6 +337,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_010_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_010_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_010_Red/imaging_plane -> /general/optophysiology/Zstack0027_red
+/acquisition/ROI_010_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x171104c1"
 /acquisition/ROI_010_Red/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_011_Green
@@ -333,6 +353,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_011_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_011_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_011_Green/imaging_plane -> /general/optophysiology/Zstack0027_green
+/acquisition/ROI_011_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x1076035a"
 /acquisition/ROI_011_Green/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_011_Red
@@ -348,6 +369,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_011_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_011_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_011_Red/imaging_plane -> /general/optophysiology/Zstack0027_red
+/acquisition/ROI_011_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x1076035a"
 /acquisition/ROI_011_Red/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_012_Green
@@ -363,6 +385,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_012_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_012_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_012_Green/imaging_plane -> /general/optophysiology/Zstack0027_green
+/acquisition/ROI_012_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xdd802f2"
 /acquisition/ROI_012_Green/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_012_Red
@@ -378,6 +401,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_012_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_012_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_012_Red/imaging_plane -> /general/optophysiology/Zstack0027_red
+/acquisition/ROI_012_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xdd802f2"
 /acquisition/ROI_012_Red/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_013_Green
@@ -393,6 +417,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_013_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_013_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_013_Green/imaging_plane -> /general/optophysiology/Zstack0029_green
+/acquisition/ROI_013_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xa3b028a"
 /acquisition/ROI_013_Green/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_013_Red
@@ -408,6 +433,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_013_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_013_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_013_Red/imaging_plane -> /general/optophysiology/Zstack0029_red
+/acquisition/ROI_013_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xa3b028a"
 /acquisition/ROI_013_Red/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_014_Green
@@ -423,6 +449,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_014_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_014_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_014_Green/imaging_plane -> /general/optophysiology/Zstack0029_green
+/acquisition/ROI_014_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xe9f0322"
 /acquisition/ROI_014_Green/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_014_Red
@@ -438,6 +465,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_014_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_014_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_014_Red/imaging_plane -> /general/optophysiology/Zstack0029_red
+/acquisition/ROI_014_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xe9f0322"
 /acquisition/ROI_014_Red/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_015_Green
@@ -453,6 +481,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_015_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_015_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_015_Green/imaging_plane -> /general/optophysiology/Zstack0029_green
+/acquisition/ROI_015_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x13fa03b9"
 /acquisition/ROI_015_Green/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_015_Red
@@ -468,6 +497,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_015_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_015_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_015_Red/imaging_plane -> /general/optophysiology/Zstack0029_red
+/acquisition/ROI_015_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x13fa03b9"
 /acquisition/ROI_015_Red/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_016_Green
@@ -483,6 +513,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_016_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_016_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_016_Green/imaging_plane -> /general/optophysiology/Zstack0030_green
+/acquisition/ROI_016_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x105d0351"
 /acquisition/ROI_016_Green/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_016_Red
@@ -498,6 +529,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_016_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_016_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_016_Red/imaging_plane -> /general/optophysiology/Zstack0030_red
+/acquisition/ROI_016_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x105d0351"
 /acquisition/ROI_016_Red/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_017_Green
@@ -513,6 +545,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_017_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_017_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_017_Green/imaging_plane -> /general/optophysiology/Zstack0030_green
+/acquisition/ROI_017_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x14b903e8"
 /acquisition/ROI_017_Green/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_017_Red
@@ -528,6 +561,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_017_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_017_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_017_Red/imaging_plane -> /general/optophysiology/Zstack0030_red
+/acquisition/ROI_017_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x14b903e8"
 /acquisition/ROI_017_Red/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_018_Green
@@ -543,6 +577,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_018_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_018_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_018_Green/imaging_plane -> /general/optophysiology/Zstack0028_green
+/acquisition/ROI_018_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x121b0380"
 /acquisition/ROI_018_Green/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_018_Red
@@ -558,6 +593,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_018_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_018_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_018_Red/imaging_plane -> /general/optophysiology/Zstack0028_red
+/acquisition/ROI_018_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x121b0380"
 /acquisition/ROI_018_Red/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_019_Green
@@ -573,6 +609,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_019_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_019_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_019_Green/imaging_plane -> /general/optophysiology/Zstack0028_green
+/acquisition/ROI_019_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x16770417"
 /acquisition/ROI_019_Green/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_019_Red
@@ -588,6 +625,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_019_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_019_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_019_Red/imaging_plane -> /general/optophysiology/Zstack0028_red
+/acquisition/ROI_019_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x16770417"
 /acquisition/ROI_019_Red/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_020_Green
@@ -603,6 +641,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_020_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_020_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_020_Green/imaging_plane -> /general/optophysiology/Zstack0031_green
+/acquisition/ROI_020_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xbe002b0"
 /acquisition/ROI_020_Green/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_020_Red
@@ -618,6 +657,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_020_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_020_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_020_Red/imaging_plane -> /general/optophysiology/Zstack0031_red
+/acquisition/ROI_020_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xbe002b0"
 /acquisition/ROI_020_Red/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_021_Green
@@ -633,6 +673,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_021_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_021_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_021_Green/imaging_plane -> /general/optophysiology/Zstack0031_green
+/acquisition/ROI_021_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x16370446"
 /acquisition/ROI_021_Green/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_021_Red
@@ -648,6 +689,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_021_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_021_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_021_Red/imaging_plane -> /general/optophysiology/Zstack0031_red
+/acquisition/ROI_021_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x16370446"
 /acquisition/ROI_021_Red/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_022_Green
@@ -663,6 +705,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_022_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_022_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_022_Green/imaging_plane -> /general/optophysiology/Zstack0031_green
+/acquisition/ROI_022_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xd9e02df"
 /acquisition/ROI_022_Green/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_022_Red
@@ -678,6 +721,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_022_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_022_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_022_Red/imaging_plane -> /general/optophysiology/Zstack0031_red
+/acquisition/ROI_022_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xd9e02df"
 /acquisition/ROI_022_Red/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_023_Green
@@ -693,6 +737,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_023_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_023_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_023_Green/imaging_plane -> /general/optophysiology/Zstack0031_green
+/acquisition/ROI_023_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x15000476"
 /acquisition/ROI_023_Green/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_023_Red
@@ -708,6 +753,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_023_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_023_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_023_Red/imaging_plane -> /general/optophysiology/Zstack0031_red
+/acquisition/ROI_023_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x15000476"
 /acquisition/ROI_023_Red/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_024_Green
@@ -723,6 +769,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_024_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_024_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_024_Green/imaging_plane -> /general/optophysiology/Zstack0031_green
+/acquisition/ROI_024_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x175e050d"
 /acquisition/ROI_024_Green/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_024_Red
@@ -738,6 +785,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_024_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_024_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_024_Red/imaging_plane -> /general/optophysiology/Zstack0031_red
+/acquisition/ROI_024_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x175e050d"
 /acquisition/ROI_024_Red/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_025_Green
@@ -753,6 +801,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_025_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_025_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_025_Green/imaging_plane -> /general/optophysiology/Zstack0031_green
+/acquisition/ROI_025_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x13480399"
 /acquisition/ROI_025_Green/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_025_Red
@@ -768,6 +817,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_025_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_025_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_025_Red/imaging_plane -> /general/optophysiology/Zstack0031_red
+/acquisition/ROI_025_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x13480399"
 /acquisition/ROI_025_Red/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_026_Green
@@ -783,6 +833,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_026_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_026_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_026_Green/imaging_plane -> /general/optophysiology/Zstack0031_green
+/acquisition/ROI_026_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x127d03e5"
 /acquisition/ROI_026_Green/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_026_Red
@@ -798,6 +849,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_026_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_026_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_026_Red/imaging_plane -> /general/optophysiology/Zstack0031_red
+/acquisition/ROI_026_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x127d03e5"
 /acquisition/ROI_026_Red/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_027_Green
@@ -813,6 +865,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_027_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_027_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_027_Green/imaging_plane -> /general/optophysiology/Zstack0032_green
+/acquisition/ROI_027_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xfab0331"
 /acquisition/ROI_027_Green/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_027_Red
@@ -828,6 +881,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_027_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_027_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_027_Red/imaging_plane -> /general/optophysiology/Zstack0032_red
+/acquisition/ROI_027_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xfab0331"
 /acquisition/ROI_027_Red/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_028_Green
@@ -843,6 +897,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_028_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_028_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_028_Green/imaging_plane -> /general/optophysiology/Zstack0032_green
+/acquisition/ROI_028_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xfdf037d"
 /acquisition/ROI_028_Green/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_028_Red
@@ -858,6 +913,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_028_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_028_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_028_Red/imaging_plane -> /general/optophysiology/Zstack0032_red
+/acquisition/ROI_028_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xfdf037d"
 /acquisition/ROI_028_Red/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_029_Green
@@ -873,6 +929,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_029_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_029_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_029_Green/imaging_plane -> /general/optophysiology/Zstack0032_green
+/acquisition/ROI_029_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x131003c9"
 /acquisition/ROI_029_Green/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_029_Red
@@ -888,6 +945,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_029_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_029_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_029_Red/imaging_plane -> /general/optophysiology/Zstack0032_red
+/acquisition/ROI_029_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x131003c9"
 /acquisition/ROI_029_Red/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_030_Green
@@ -903,6 +961,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_030_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_030_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_030_Green/imaging_plane -> /general/optophysiology/Zstack0030_green
+/acquisition/ROI_030_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x7460216"
 /acquisition/ROI_030_Green/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_030_Red
@@ -918,6 +977,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_030_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_030_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_030_Red/imaging_plane -> /general/optophysiology/Zstack0030_red
+/acquisition/ROI_030_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x7460216"
 /acquisition/ROI_030_Red/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_031_Green
@@ -933,6 +993,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_031_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_031_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_031_Green/imaging_plane -> /general/optophysiology/Zstack0030_green
+/acquisition/ROI_031_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xf730361"
 /acquisition/ROI_031_Green/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_031_Red
@@ -948,6 +1009,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_031_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_031_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_031_Red/imaging_plane -> /general/optophysiology/Zstack0030_red
+/acquisition/ROI_031_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xf730361"
 /acquisition/ROI_031_Red/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_032_Green
@@ -963,6 +1025,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_032_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_032_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_032_Green/imaging_plane -> /general/optophysiology/Zstack0030_green
+/acquisition/ROI_032_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x119d03ac"
 /acquisition/ROI_032_Green/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_032_Red
@@ -978,6 +1041,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_032_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_032_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_032_Red/imaging_plane -> /general/optophysiology/Zstack0030_red
+/acquisition/ROI_032_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x119d03ac"
 /acquisition/ROI_032_Red/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_033_Green
@@ -993,6 +1057,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_033_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_033_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_033_Green/imaging_plane -> /general/optophysiology/Zstack0030_green
+/acquisition/ROI_033_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xed302f9"
 /acquisition/ROI_033_Green/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_033_Red
@@ -1008,6 +1073,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_033_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_033_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_033_Red/imaging_plane -> /general/optophysiology/Zstack0030_red
+/acquisition/ROI_033_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xed302f9"
 /acquisition/ROI_033_Red/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_034_Green
@@ -1023,6 +1089,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_034_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_034_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_034_Green/imaging_plane -> /general/optophysiology/Zstack0030_green
+/acquisition/ROI_034_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x15f90443"
 /acquisition/ROI_034_Green/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_034_Red
@@ -1038,6 +1105,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_034_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_034_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_034_Red/imaging_plane -> /general/optophysiology/Zstack0030_red
+/acquisition/ROI_034_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x15f90443"
 /acquisition/ROI_034_Red/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_035_Green
@@ -1053,6 +1121,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_035_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_035_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_035_Green/imaging_plane -> /general/optophysiology/Zstack0030_green
+/acquisition/ROI_035_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x11310390"
 /acquisition/ROI_035_Green/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_035_Red
@@ -1068,6 +1137,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_035_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_035_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_035_Red/imaging_plane -> /general/optophysiology/Zstack0030_red
+/acquisition/ROI_035_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x11310390"
 /acquisition/ROI_035_Red/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_036_Green
@@ -1083,6 +1153,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_036_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_036_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_036_Green/imaging_plane -> /general/optophysiology/Zstack0030_green
+/acquisition/ROI_036_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xd6002dc"
 /acquisition/ROI_036_Green/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_036_Red
@@ -1098,6 +1169,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_036_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_036_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_036_Red/imaging_plane -> /general/optophysiology/Zstack0030_red
+/acquisition/ROI_036_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xd6002dc"
 /acquisition/ROI_036_Red/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_037_Green
@@ -1113,6 +1185,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_037_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_037_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_037_Green/imaging_plane -> /general/optophysiology/Zstack0030_green
+/acquisition/ROI_037_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x158d0427"
 /acquisition/ROI_037_Green/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_037_Red
@@ -1128,6 +1201,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_037_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_037_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_037_Red/imaging_plane -> /general/optophysiology/Zstack0030_red
+/acquisition/ROI_037_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x158d0427"
 /acquisition/ROI_037_Red/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_038_Green
@@ -1143,6 +1217,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_038_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_038_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_038_Green/imaging_plane -> /general/optophysiology/Zstack0029_green
+/acquisition/ROI_038_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x17bf0473"
 /acquisition/ROI_038_Green/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_038_Red
@@ -1158,6 +1233,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_038_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_038_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_038_Red/imaging_plane -> /general/optophysiology/Zstack0029_red
+/acquisition/ROI_038_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x17bf0473"
 /acquisition/ROI_038_Red/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_039_Green
@@ -1173,6 +1249,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_039_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_039_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_039_Green/imaging_plane -> /general/optophysiology/Zstack0029_green
+/acquisition/ROI_039_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xbf502c0"
 /acquisition/ROI_039_Green/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_039_Red
@@ -1188,6 +1265,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_039_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_039_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_039_Red/imaging_plane -> /general/optophysiology/Zstack0029_red
+/acquisition/ROI_039_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xbf502c0"
 /acquisition/ROI_039_Red/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_040_Green
@@ -1203,6 +1281,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_040_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_040_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_040_Green/imaging_plane -> /general/optophysiology/Zstack0029_green
+/acquisition/ROI_040_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x1422040b"
 /acquisition/ROI_040_Green/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_040_Red
@@ -1218,6 +1297,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_040_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_040_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_040_Red/imaging_plane -> /general/optophysiology/Zstack0029_red
+/acquisition/ROI_040_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x1422040b"
 /acquisition/ROI_040_Red/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_041_Green
@@ -1233,6 +1313,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_041_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_041_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_041_Green/imaging_plane -> /general/optophysiology/Zstack0029_green
+/acquisition/ROI_041_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x164c0456"
 /acquisition/ROI_041_Green/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_041_Red
@@ -1248,6 +1329,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_041_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_041_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_041_Red/imaging_plane -> /general/optophysiology/Zstack0029_red
+/acquisition/ROI_041_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x164c0456"
 /acquisition/ROI_041_Red/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_042_Green
@@ -1263,6 +1345,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_042_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_042_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_042_Green/imaging_plane -> /general/optophysiology/Zstack0029_green
+/acquisition/ROI_042_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x187e04a2"
 /acquisition/ROI_042_Green/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_042_Red
@@ -1278,6 +1361,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_042_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_042_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_042_Red/imaging_plane -> /general/optophysiology/Zstack0029_red
+/acquisition/ROI_042_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x187e04a2"
 /acquisition/ROI_042_Red/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_043_Green
@@ -1293,6 +1377,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_043_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_043_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_043_Green/imaging_plane -> /general/optophysiology/Zstack0033_green
+/acquisition/ROI_043_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x12af03ee"
 /acquisition/ROI_043_Green/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_043_Red
@@ -1308,6 +1393,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_043_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_043_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_043_Red/imaging_plane -> /general/optophysiology/Zstack0033_red
+/acquisition/ROI_043_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x12af03ee"
 /acquisition/ROI_043_Red/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_044_Green
@@ -1323,6 +1409,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_044_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_044_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_044_Green/imaging_plane -> /general/optophysiology/Zstack0033_green
+/acquisition/ROI_044_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xee6033b"
 /acquisition/ROI_044_Green/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_044_Red
@@ -1338,6 +1425,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_044_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_044_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_044_Red/imaging_plane -> /general/optophysiology/Zstack0033_red
+/acquisition/ROI_044_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xee6033b"
 /acquisition/ROI_044_Red/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_045_Green
@@ -1353,6 +1441,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_045_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_045_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_045_Green/imaging_plane -> /general/optophysiology/Zstack0033_green
+/acquisition/ROI_045_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x10110386"
 /acquisition/ROI_045_Green/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_045_Red
@@ -1368,6 +1457,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_045_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_045_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_045_Red/imaging_plane -> /general/optophysiology/Zstack0033_red
+/acquisition/ROI_045_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x10110386"
 /acquisition/ROI_045_Red/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_046_Green
@@ -1383,6 +1473,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_046_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_046_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_046_Green/imaging_plane -> /general/optophysiology/Zstack0032_green
+/acquisition/ROI_046_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x134203d2"
 /acquisition/ROI_046_Green/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_046_Red
@@ -1398,6 +1489,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_046_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_046_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_046_Red/imaging_plane -> /general/optophysiology/Zstack0032_red
+/acquisition/ROI_046_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x134203d2"
 /acquisition/ROI_046_Red/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_047_Green
@@ -1413,6 +1505,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_047_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_047_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_047_Green/imaging_plane -> /general/optophysiology/Zstack0032_green
+/acquisition/ROI_047_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xd7b031f"
 /acquisition/ROI_047_Green/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_047_Red
@@ -1428,6 +1521,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_047_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_047_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_047_Red/imaging_plane -> /general/optophysiology/Zstack0032_red
+/acquisition/ROI_047_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xd7b031f"
 /acquisition/ROI_047_Red/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_048_Green
@@ -1443,6 +1537,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_048_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_048_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_048_Green/imaging_plane -> /general/optophysiology/Zstack0032_green
+/acquisition/ROI_048_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xfa5036a"
 /acquisition/ROI_048_Green/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_048_Red
@@ -1458,6 +1553,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_048_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_048_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_048_Red/imaging_plane -> /general/optophysiology/Zstack0032_red
+/acquisition/ROI_048_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xfa5036a"
 /acquisition/ROI_048_Red/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_049_Green
@@ -1473,6 +1569,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_049_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_049_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_049_Green/imaging_plane -> /general/optophysiology/Zstack0032_green
+/acquisition/ROI_049_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x11d703b6"
 /acquisition/ROI_049_Green/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_049_Red
@@ -1488,6 +1585,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_049_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_049_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_049_Red/imaging_plane -> /general/optophysiology/Zstack0032_red
+/acquisition/ROI_049_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x11d703b6"
 /acquisition/ROI_049_Red/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_050_Green
@@ -1503,6 +1601,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_050_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_050_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_050_Green/imaging_plane -> /general/optophysiology/Zstack0031_green
+/acquisition/ROI_050_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xf050302"
 /acquisition/ROI_050_Green/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_050_Red
@@ -1518,6 +1617,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_050_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_050_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_050_Red/imaging_plane -> /general/optophysiology/Zstack0031_red
+/acquisition/ROI_050_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xf050302"
 /acquisition/ROI_050_Red/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_051_Green
@@ -1533,6 +1633,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_051_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_051_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_051_Green/imaging_plane -> /general/optophysiology/Zstack0031_green
+/acquisition/ROI_051_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x1633044d"
 /acquisition/ROI_051_Green/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_051_Red
@@ -1548,6 +1649,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_051_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_051_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_051_Red/imaging_plane -> /general/optophysiology/Zstack0031_red
+/acquisition/ROI_051_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x1633044d"
 /acquisition/ROI_051_Red/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_052_Green
@@ -1563,6 +1665,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_052_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_052_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_052_Green/imaging_plane -> /general/optophysiology/Zstack0031_green
+/acquisition/ROI_052_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xd66029a"
 /acquisition/ROI_052_Green/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_052_Red
@@ -1578,6 +1681,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_052_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_052_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_052_Red/imaging_plane -> /general/optophysiology/Zstack0031_red
+/acquisition/ROI_052_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xd66029a"
 /acquisition/ROI_052_Red/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_053_Green
@@ -1593,6 +1697,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_053_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_053_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_053_Green/imaging_plane -> /general/optophysiology/Zstack0030_green
+/acquisition/ROI_053_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xd9a02e6"
 /acquisition/ROI_053_Green/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_053_Red
@@ -1608,6 +1713,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_053_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_053_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_053_Red/imaging_plane -> /general/optophysiology/Zstack0030_red
+/acquisition/ROI_053_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xd9a02e6"
 /acquisition/ROI_053_Red/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_054_Green
@@ -1623,6 +1729,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_054_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_054_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_054_Green/imaging_plane -> /general/optophysiology/Zstack0030_green
+/acquisition/ROI_054_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x14c00430"
 /acquisition/ROI_054_Green/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_054_Red
@@ -1638,6 +1745,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_054_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_054_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_054_Red/imaging_plane -> /general/optophysiology/Zstack0030_red
+/acquisition/ROI_054_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x14c00430"
 /acquisition/ROI_054_Red/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_055_Green
@@ -1653,6 +1761,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_055_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_055_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_055_Green/imaging_plane -> /general/optophysiology/Zstack0030_green
+/acquisition/ROI_055_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x17f1047c"
 /acquisition/ROI_055_Green/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_055_Red
@@ -1668,6 +1777,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_055_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_055_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_055_Red/imaging_plane -> /general/optophysiology/Zstack0030_red
+/acquisition/ROI_055_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x17f1047c"
 /acquisition/ROI_055_Red/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_056_Green
@@ -1683,6 +1793,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_056_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_056_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_056_Green/imaging_plane -> /general/optophysiology/Zstack0030_green
+/acquisition/ROI_056_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x112b03c9"
 /acquisition/ROI_056_Green/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_056_Red
@@ -1698,6 +1809,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_056_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_056_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_056_Red/imaging_plane -> /general/optophysiology/Zstack0030_red
+/acquisition/ROI_056_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x112b03c9"
 /acquisition/ROI_056_Red/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_057_Green
@@ -1713,6 +1825,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_057_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_057_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_057_Green/imaging_plane -> /general/optophysiology/Zstack0030_green
+/acquisition/ROI_057_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x14540414"
 /acquisition/ROI_057_Green/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_057_Red
@@ -1728,6 +1841,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_057_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_057_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_057_Red/imaging_plane -> /general/optophysiology/Zstack0030_red
+/acquisition/ROI_057_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x14540414"
 /acquisition/ROI_057_Red/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_058_Green
@@ -1743,6 +1857,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_058_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_058_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_058_Green/imaging_plane -> /general/optophysiology/Zstack0031_green
+/acquisition/ROI_058_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x16860460"
 /acquisition/ROI_058_Green/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_058_Red
@@ -1758,6 +1873,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_058_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_058_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_058_Red/imaging_plane -> /general/optophysiology/Zstack0031_red
+/acquisition/ROI_058_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x16860460"
 /acquisition/ROI_058_Red/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_059_Green
@@ -1773,6 +1889,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_059_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_059_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_059_Green/imaging_plane -> /general/optophysiology/Zstack0031_green
+/acquisition/ROI_059_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x115c03a5"
 /acquisition/ROI_059_Green/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_059_Red
@@ -1788,6 +1905,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_059_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_059_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_059_Red/imaging_plane -> /general/optophysiology/Zstack0031_red
+/acquisition/ROI_059_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x115c03a5"
 /acquisition/ROI_059_Red/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_060_Green
@@ -1803,6 +1921,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_060_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_060_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_060_Green/imaging_plane -> /general/optophysiology/Zstack0031_green
+/acquisition/ROI_060_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xef4034b"
 /acquisition/ROI_060_Green/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_060_Red
@@ -1818,6 +1937,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_060_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_060_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_060_Red/imaging_plane -> /general/optophysiology/Zstack0031_red
+/acquisition/ROI_060_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xef4034b"
 /acquisition/ROI_060_Red/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_061_Green
@@ -1833,6 +1953,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_061_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_061_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_061_Green/imaging_plane -> /general/optophysiology/Zstack0031_green
+/acquisition/ROI_061_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x108b0311"
 /acquisition/ROI_061_Green/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_061_Red
@@ -1848,6 +1969,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_061_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_061_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_061_Red/imaging_plane -> /general/optophysiology/Zstack0031_red
+/acquisition/ROI_061_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x108b0311"
 /acquisition/ROI_061_Red/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_062_Green
@@ -1863,6 +1985,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_062_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_062_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_062_Green/imaging_plane -> /general/optophysiology/Zstack0032_green
+/acquisition/ROI_062_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xe2b02b8"
 /acquisition/ROI_062_Green/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_062_Red
@@ -1878,6 +2001,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_062_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_062_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_062_Red/imaging_plane -> /general/optophysiology/Zstack0032_red
+/acquisition/ROI_062_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xe2b02b8"
 /acquisition/ROI_062_Red/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_063_Green
@@ -1893,6 +2017,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_063_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_063_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_063_Green/imaging_plane -> /general/optophysiology/Zstack0032_green
+/acquisition/ROI_063_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xac4025e"
 /acquisition/ROI_063_Green/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_063_Red
@@ -1908,6 +2033,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_063_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_063_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_063_Red/imaging_plane -> /general/optophysiology/Zstack0032_red
+/acquisition/ROI_063_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xac4025e"
 /acquisition/ROI_063_Red/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_064_Green
@@ -1923,6 +2049,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_064_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_064_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_064_Green/imaging_plane -> /general/optophysiology/Zstack0032_green
+/acquisition/ROI_064_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x11550402"
 /acquisition/ROI_064_Green/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_064_Red
@@ -1938,6 +2065,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_064_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_064_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_064_Red/imaging_plane -> /general/optophysiology/Zstack0032_red
+/acquisition/ROI_064_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x11550402"
 /acquisition/ROI_064_Red/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_065_Green
@@ -1953,6 +2081,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_065_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_065_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_065_Green/imaging_plane -> /general/optophysiology/Zstack0032_green
+/acquisition/ROI_065_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x15e704a7"
 /acquisition/ROI_065_Green/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_065_Red
@@ -1968,6 +2097,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_065_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_065_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_065_Red/imaging_plane -> /general/optophysiology/Zstack0032_red
+/acquisition/ROI_065_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x15e704a7"
 /acquisition/ROI_065_Red/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_066_Green
@@ -1983,6 +2113,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_066_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_066_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_066_Green/imaging_plane -> /general/optophysiology/Zstack0034_green
+/acquisition/ROI_066_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x1089034f"
 /acquisition/ROI_066_Green/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_066_Red
@@ -1998,6 +2129,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_066_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_066_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_066_Red/imaging_plane -> /general/optophysiology/Zstack0034_red
+/acquisition/ROI_066_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x1089034f"
 /acquisition/ROI_066_Red/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_067_Green
@@ -2013,6 +2145,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_067_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_067_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_067_Green/imaging_plane -> /general/optophysiology/Zstack0034_green
+/acquisition/ROI_067_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xf2002f5"
 /acquisition/ROI_067_Green/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_067_Red
@@ -2028,6 +2161,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_067_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_067_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_067_Red/imaging_plane -> /general/optophysiology/Zstack0034_red
+/acquisition/ROI_067_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xf2002f5"
 /acquisition/ROI_067_Red/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_068_Green
@@ -2043,6 +2177,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_068_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_068_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_068_Green/imaging_plane -> /general/optophysiology/Zstack0034_green
+/acquisition/ROI_068_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x10b5039a"
 /acquisition/ROI_068_Green/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_068_Red
@@ -2058,6 +2193,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_068_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_068_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_068_Red/imaging_plane -> /general/optophysiology/Zstack0034_red
+/acquisition/ROI_068_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x10b5039a"
 /acquisition/ROI_068_Red/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_069_Green
@@ -2073,6 +2209,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_069_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_069_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_069_Green/imaging_plane -> /general/optophysiology/Zstack0034_green
+/acquisition/ROI_069_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x1a43053e"
 /acquisition/ROI_069_Green/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_069_Red
@@ -2088,6 +2225,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_069_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_069_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_069_Red/imaging_plane -> /general/optophysiology/Zstack0034_red
+/acquisition/ROI_069_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x1a43053e"
 /acquisition/ROI_069_Red/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_070_Green
@@ -2103,6 +2241,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_070_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_070_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_070_Green/imaging_plane -> /general/optophysiology/Zstack0034_green
+/acquisition/ROI_070_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x14e503e6"
 /acquisition/ROI_070_Green/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_070_Red
@@ -2118,6 +2257,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_070_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_070_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_070_Red/imaging_plane -> /general/optophysiology/Zstack0034_red
+/acquisition/ROI_070_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x14e503e6"
 /acquisition/ROI_070_Red/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_071_Green
@@ -2133,6 +2273,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_071_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_071_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_071_Green/imaging_plane -> /general/optophysiology/Zstack0034_green
+/acquisition/ROI_071_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x117e038c"
 /acquisition/ROI_071_Green/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_071_Red
@@ -2148,6 +2289,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_071_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_071_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_071_Red/imaging_plane -> /general/optophysiology/Zstack0034_red
+/acquisition/ROI_071_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x117e038c"
 /acquisition/ROI_071_Red/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_072_Green
@@ -2163,6 +2305,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_072_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_072_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_072_Green/imaging_plane -> /general/optophysiology/Zstack0035_green
+/acquisition/ROI_072_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x13130431"
 /acquisition/ROI_072_Green/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_072_Red
@@ -2178,6 +2321,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_072_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_072_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_072_Red/imaging_plane -> /general/optophysiology/Zstack0035_red
+/acquisition/ROI_072_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x13130431"
 /acquisition/ROI_072_Red/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_073_Green
@@ -2193,6 +2337,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_073_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_073_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_073_Green/imaging_plane -> /general/optophysiology/Zstack0035_green
+/acquisition/ROI_073_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xab802d9"
 /acquisition/ROI_073_Green/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_073_Red
@@ -2208,6 +2353,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_073_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_073_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_073_Red/imaging_plane -> /general/optophysiology/Zstack0035_red
+/acquisition/ROI_073_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xab802d9"
 /acquisition/ROI_073_Red/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_074_Green
@@ -2223,6 +2369,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_074_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_074_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_074_Green/imaging_plane -> /general/optophysiology/Zstack0035_green
+/acquisition/ROI_074_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xc4c027f"
 /acquisition/ROI_074_Green/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_074_Red
@@ -2238,6 +2385,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_074_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_074_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_074_Red/imaging_plane -> /general/optophysiology/Zstack0035_red
+/acquisition/ROI_074_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xc4c027f"
 /acquisition/ROI_074_Red/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_075_Green
@@ -2253,6 +2401,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_075_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_075_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_075_Green/imaging_plane -> /general/optophysiology/Zstack0035_green
+/acquisition/ROI_075_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xee00324"
 /acquisition/ROI_075_Green/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_075_Red
@@ -2268,6 +2417,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_075_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_075_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_075_Red/imaging_plane -> /general/optophysiology/Zstack0035_red
+/acquisition/ROI_075_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xee00324"
 /acquisition/ROI_075_Red/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_076_Green
@@ -2283,6 +2433,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_076_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_076_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_076_Green/imaging_plane -> /general/optophysiology/Zstack0035_green
+/acquisition/ROI_076_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x137203c9"
 /acquisition/ROI_076_Green/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_076_Red
@@ -2298,6 +2449,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_076_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_076_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_076_Red/imaging_plane -> /general/optophysiology/Zstack0035_red
+/acquisition/ROI_076_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x137203c9"
 /acquisition/ROI_076_Red/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_077_Green
@@ -2313,6 +2465,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_077_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_077_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_077_Green/imaging_plane -> /general/optophysiology/Zstack0037_green
+/acquisition/ROI_077_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x150f046f"
 /acquisition/ROI_077_Green/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_077_Red
@@ -2328,6 +2481,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_077_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_077_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_077_Red/imaging_plane -> /general/optophysiology/Zstack0037_red
+/acquisition/ROI_077_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x150f046f"
 /acquisition/ROI_077_Red/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_078_Green
@@ -2343,6 +2497,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_078_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_078_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_078_Green/imaging_plane -> /general/optophysiology/Zstack0037_green
+/acquisition/ROI_078_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x19a10514"
 /acquisition/ROI_078_Green/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_078_Red
@@ -2358,6 +2513,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_078_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_078_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_078_Red/imaging_plane -> /general/optophysiology/Zstack0037_red
+/acquisition/ROI_078_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x19a10514"
 /acquisition/ROI_078_Red/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_079_Green
@@ -2373,6 +2529,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_079_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_079_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_079_Green/imaging_plane -> /general/optophysiology/Zstack0037_green
+/acquisition/ROI_079_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xe4002bc"
 /acquisition/ROI_079_Green/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_079_Red
@@ -2388,6 +2545,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_079_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_079_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_079_Red/imaging_plane -> /general/optophysiology/Zstack0037_red
+/acquisition/ROI_079_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xe4002bc"
 /acquisition/ROI_079_Red/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_080_Green
@@ -2403,6 +2561,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_080_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_080_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_080_Green/imaging_plane -> /general/optophysiology/Zstack0036_green
+/acquisition/ROI_080_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xae10263"
 /acquisition/ROI_080_Green/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_080_Red
@@ -2418,6 +2577,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_080_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_080_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_080_Red/imaging_plane -> /general/optophysiology/Zstack0036_red
+/acquisition/ROI_080_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xae10263"
 /acquisition/ROI_080_Red/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_081_Green
@@ -2433,6 +2593,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_081_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_081_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_081_Green/imaging_plane -> /general/optophysiology/Zstack0036_green
+/acquisition/ROI_081_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x11720407"
 /acquisition/ROI_081_Green/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_081_Red
@@ -2448,6 +2609,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_081_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_081_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_081_Red/imaging_plane -> /general/optophysiology/Zstack0036_red
+/acquisition/ROI_081_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x11720407"
 /acquisition/ROI_081_Red/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_082_Green
@@ -2463,6 +2625,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_082_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_082_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_082_Green/imaging_plane -> /general/optophysiology/Zstack0031_green
+/acquisition/ROI_082_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x160404ac"
 /acquisition/ROI_082_Green/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_082_Red
@@ -2478,6 +2641,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_082_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_082_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_082_Red/imaging_plane -> /general/optophysiology/Zstack0031_red
+/acquisition/ROI_082_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x160404ac"
 /acquisition/ROI_082_Red/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_083_Green
@@ -2493,6 +2657,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_083_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_083_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_083_Green/imaging_plane -> /general/optophysiology/Zstack0032_green
+/acquisition/ROI_083_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x109e0353"
 /acquisition/ROI_083_Green/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_083_Red
@@ -2508,6 +2673,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_083_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_083_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_083_Red/imaging_plane -> /general/optophysiology/Zstack0032_red
+/acquisition/ROI_083_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x109e0353"
 /acquisition/ROI_083_Red/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_084_Green
@@ -2523,6 +2689,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_084_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_084_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_084_Green/imaging_plane -> /general/optophysiology/Zstack0032_green
+/acquisition/ROI_084_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xf3d02fa"
 /acquisition/ROI_084_Green/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_084_Red
@@ -2538,6 +2705,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_084_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_084_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_084_Red/imaging_plane -> /general/optophysiology/Zstack0032_red
+/acquisition/ROI_084_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xf3d02fa"
 /acquisition/ROI_084_Red/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_085_Green
@@ -2553,6 +2721,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_085_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_085_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_085_Green/imaging_plane -> /general/optophysiology/Zstack0032_green
+/acquisition/ROI_085_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x10d2039f"
 /acquisition/ROI_085_Green/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_085_Red
@@ -2568,6 +2737,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_085_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_085_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_085_Red/imaging_plane -> /general/optophysiology/Zstack0032_red
+/acquisition/ROI_085_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x10d2039f"
 /acquisition/ROI_085_Red/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_086_Green
@@ -2583,6 +2753,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_086_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_086_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_086_Green/imaging_plane -> /general/optophysiology/Zstack0032_green
+/acquisition/ROI_086_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x1a600543"
 /acquisition/ROI_086_Green/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_086_Red
@@ -2598,6 +2769,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_086_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_086_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_086_Red/imaging_plane -> /general/optophysiology/Zstack0032_red
+/acquisition/ROI_086_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x1a600543"
 /acquisition/ROI_086_Red/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_087_Green
@@ -2613,6 +2785,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_087_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_087_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_087_Green/imaging_plane -> /general/optophysiology/Zstack0033_green
+/acquisition/ROI_087_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x14fa03ea"
 /acquisition/ROI_087_Green/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_087_Red
@@ -2628,6 +2801,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_087_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_087_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_087_Red/imaging_plane -> /general/optophysiology/Zstack0033_red
+/acquisition/ROI_087_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x14fa03ea"
 /acquisition/ROI_087_Red/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_088_Green
@@ -2643,6 +2817,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_088_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_088_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_088_Green/imaging_plane -> /general/optophysiology/Zstack0033_green
+/acquisition/ROI_088_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xaa10292"
 /acquisition/ROI_088_Green/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_088_Red
@@ -2658,6 +2833,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_088_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_088_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_088_Red/imaging_plane -> /general/optophysiology/Zstack0033_red
+/acquisition/ROI_088_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xaa10292"
 /acquisition/ROI_088_Red/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_089_Green
@@ -2673,6 +2849,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_089_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_089_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_089_Green/imaging_plane -> /general/optophysiology/Zstack0022_green
+/acquisition/ROI_089_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xf330337"
 /acquisition/ROI_089_Green/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/ROI_089_Red
@@ -2688,6 +2865,7 @@ Generating signature for 161222_16_18_47.nwb
 /acquisition/ROI_089_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_089_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_089_Red/imaging_plane -> /general/optophysiology/Zstack0022_red
+/acquisition/ROI_089_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xf330337"
 /acquisition/ROI_089_Red/timestamps: dtype=float64 shape=(157700,) val="0x23b3a8a1"
 	@unit: type=str val="seconds"
 /acquisition/WhiskersCam
@@ -4937,6 +5115,7 @@ Generating signature for 161222_16_18_47.nwb
 /general/optophysiology/Zstack0041_red/reference_frame: dtype=object shape=() val="TODO: In lab book (partly?)"
 /general/session_id: dtype=object shape=() val="161222_16_18_47"
 /general/silverlab_metadata
+	@labview_version: type=str val="pre-2018 (original)"
 	@silverlab_api_version: type=str val="0.2"
 /general/silverlab_optophysiology
 	@cycle_time: dtype=float64 shape=() val="0.00312395"
@@ -4971,7 +5150,7 @@ Generating signature for 161222_16_18_47.nwb
 /processing/Acquired_ROIs
 	@description: type=str val="ROI locations and acquired fluorescence readings made directly by the AOL microscope."
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0022_green
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0022_green/angle_deg: dtype=float64 shape=(1,) val="[0]"
 	@description: type=str val="Angle (deg)"
@@ -4993,8 +5172,6 @@ Generating signature for 161222_16_18_47.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0022_green/pixel_mask_index: dtype=int64 shape=(1,) val="[1]"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0022_green/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0022_green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xf330337"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0022_green/reference_images/Zstack_Red_0022 -> /acquisition/Zstack_Red_0022
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0022_green/reference_images/reference_images -> /acquisition/Zstack_Red_0022
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0022_green/roi_group_id: dtype=float64 shape=(1,) val="[0]"
@@ -5018,7 +5195,7 @@ Generating signature for 161222_16_18_47.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0022_green/zoom: dtype=float64 shape=(1,) val="[1]"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0022_red
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0022_red/angle_deg: dtype=float64 shape=(1,) val="[0]"
 	@description: type=str val="Angle (deg)"
@@ -5040,8 +5217,6 @@ Generating signature for 161222_16_18_47.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0022_red/pixel_mask_index: dtype=int64 shape=(1,) val="[1]"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0022_red/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0022_red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xf330337"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0022_red/reference_images/Zstack_Red_0022 -> /acquisition/Zstack_Red_0022
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0022_red/reference_images/reference_images -> /acquisition/Zstack_Red_0022
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0022_red/roi_group_id: dtype=float64 shape=(1,) val="[0]"
@@ -5065,7 +5240,7 @@ Generating signature for 161222_16_18_47.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0022_red/zoom: dtype=float64 shape=(1,) val="[1]"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0025_green
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0025_green/angle_deg: dtype=float64 shape=(1,) val="[0]"
 	@description: type=str val="Angle (deg)"
@@ -5087,8 +5262,6 @@ Generating signature for 161222_16_18_47.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0025_green/pixel_mask_index: dtype=int64 shape=(1,) val="[1]"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0025_green/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0025_green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x159a045b"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0025_green/reference_images/Zstack_Red_0025 -> /acquisition/Zstack_Red_0025
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0025_green/reference_images/reference_images -> /acquisition/Zstack_Red_0025
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0025_green/roi_group_id: dtype=float64 shape=(1,) val="[0]"
@@ -5112,7 +5285,7 @@ Generating signature for 161222_16_18_47.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0025_green/zoom: dtype=float64 shape=(1,) val="[1]"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0025_red
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0025_red/angle_deg: dtype=float64 shape=(1,) val="[0]"
 	@description: type=str val="Angle (deg)"
@@ -5134,8 +5307,6 @@ Generating signature for 161222_16_18_47.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0025_red/pixel_mask_index: dtype=int64 shape=(1,) val="[1]"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0025_red/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0025_red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x159a045b"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0025_red/reference_images/Zstack_Red_0025 -> /acquisition/Zstack_Red_0025
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0025_red/reference_images/reference_images -> /acquisition/Zstack_Red_0025
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0025_red/roi_group_id: dtype=float64 shape=(1,) val="[0]"
@@ -5159,7 +5330,7 @@ Generating signature for 161222_16_18_47.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0025_red/zoom: dtype=float64 shape=(1,) val="[1]"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0026_green
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0026_green/angle_deg: dtype=float64 shape=(5,) val="0x280001"
 	@description: type=str val="Angle (deg)"
@@ -5181,8 +5352,6 @@ Generating signature for 161222_16_18_47.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0026_green/pixel_mask_index: dtype=int64 shape=(5,) val="0x1400010"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0026_green/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0026_green/pixel_time_offsets: dtype=float64 shape=(5, 1) val="0x817b118f"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0026_green/reference_images/Zstack_Red_0026 -> /acquisition/Zstack_Red_0026
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0026_green/reference_images/reference_images -> /acquisition/Zstack_Red_0026
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0026_green/roi_group_id: dtype=float64 shape=(5,) val="0x280001"
@@ -5206,7 +5375,7 @@ Generating signature for 161222_16_18_47.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0026_green/zoom: dtype=float64 shape=(5,) val="0x697305ec"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0026_red
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0026_red/angle_deg: dtype=float64 shape=(5,) val="0x280001"
 	@description: type=str val="Angle (deg)"
@@ -5228,8 +5397,6 @@ Generating signature for 161222_16_18_47.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0026_red/pixel_mask_index: dtype=int64 shape=(5,) val="0x1400010"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0026_red/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0026_red/pixel_time_offsets: dtype=float64 shape=(5, 1) val="0x817b118f"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0026_red/reference_images/Zstack_Red_0026 -> /acquisition/Zstack_Red_0026
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0026_red/reference_images/reference_images -> /acquisition/Zstack_Red_0026
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0026_red/roi_group_id: dtype=float64 shape=(5,) val="0x280001"
@@ -5253,7 +5420,7 @@ Generating signature for 161222_16_18_47.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0026_red/zoom: dtype=float64 shape=(5,) val="0x697305ec"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0027_green
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0027_green/angle_deg: dtype=float64 shape=(6,) val="0x300001"
 	@description: type=str val="Angle (deg)"
@@ -5275,8 +5442,6 @@ Generating signature for 161222_16_18_47.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0027_green/pixel_mask_index: dtype=int64 shape=(6,) val="0x1f00016"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0027_green/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0027_green/pixel_time_offsets: dtype=float64 shape=(6, 1) val="0x137115c0"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0027_green/reference_images/Zstack_Red_0027 -> /acquisition/Zstack_Red_0027
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0027_green/reference_images/reference_images -> /acquisition/Zstack_Red_0027
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0027_green/roi_group_id: dtype=float64 shape=(6,) val="0x300001"
@@ -5300,7 +5465,7 @@ Generating signature for 161222_16_18_47.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0027_green/zoom: dtype=float64 shape=(6,) val="0x9af2071b"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0027_red
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0027_red/angle_deg: dtype=float64 shape=(6,) val="0x300001"
 	@description: type=str val="Angle (deg)"
@@ -5322,8 +5487,6 @@ Generating signature for 161222_16_18_47.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0027_red/pixel_mask_index: dtype=int64 shape=(6,) val="0x1f00016"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0027_red/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0027_red/pixel_time_offsets: dtype=float64 shape=(6, 1) val="0x137115c0"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0027_red/reference_images/Zstack_Red_0027 -> /acquisition/Zstack_Red_0027
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0027_red/reference_images/reference_images -> /acquisition/Zstack_Red_0027
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0027_red/roi_group_id: dtype=float64 shape=(6,) val="0x300001"
@@ -5347,7 +5510,7 @@ Generating signature for 161222_16_18_47.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0027_red/zoom: dtype=float64 shape=(6,) val="0x9af2071b"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0028_green
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0028_green/angle_deg: dtype=float64 shape=(2,) val="0x100001"
 	@description: type=str val="Angle (deg)"
@@ -5369,8 +5532,6 @@ Generating signature for 161222_16_18_47.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0028_green/pixel_mask_index: dtype=int64 shape=(2,) val="0x300004"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0028_green/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0028_green/pixel_time_offsets: dtype=float64 shape=(2, 1) val="0x448a0796"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0028_green/reference_images/Zstack_Red_0028 -> /acquisition/Zstack_Red_0028
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0028_green/reference_images/reference_images -> /acquisition/Zstack_Red_0028
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0028_green/roi_group_id: dtype=float64 shape=(2,) val="0x100001"
@@ -5394,7 +5555,7 @@ Generating signature for 161222_16_18_47.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0028_green/zoom: dtype=float64 shape=(2,) val="0xdc6025f"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0028_red
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0028_red/angle_deg: dtype=float64 shape=(2,) val="0x100001"
 	@description: type=str val="Angle (deg)"
@@ -5416,8 +5577,6 @@ Generating signature for 161222_16_18_47.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0028_red/pixel_mask_index: dtype=int64 shape=(2,) val="0x300004"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0028_red/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0028_red/pixel_time_offsets: dtype=float64 shape=(2, 1) val="0x448a0796"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0028_red/reference_images/Zstack_Red_0028 -> /acquisition/Zstack_Red_0028
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0028_red/reference_images/reference_images -> /acquisition/Zstack_Red_0028
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0028_red/roi_group_id: dtype=float64 shape=(2,) val="0x100001"
@@ -5441,7 +5600,7 @@ Generating signature for 161222_16_18_47.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0028_red/zoom: dtype=float64 shape=(2,) val="0xdc6025f"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0029_green
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0029_green/angle_deg: dtype=float64 shape=(8,) val="0x400001"
 	@description: type=str val="Angle (deg)"
@@ -5463,8 +5622,6 @@ Generating signature for 161222_16_18_47.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0029_green/pixel_mask_index: dtype=int64 shape=(8,) val="0x4000025"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0029_green/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0029_green/pixel_time_offsets: dtype=float64 shape=(8, 1) val="0x7ff91d94"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0029_green/reference_images/Zstack_Red_0029 -> /acquisition/Zstack_Red_0029
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0029_green/reference_images/reference_images -> /acquisition/Zstack_Red_0029
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0029_green/roi_group_id: dtype=float64 shape=(8,) val="0x400001"
@@ -5488,7 +5645,7 @@ Generating signature for 161222_16_18_47.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0029_green/zoom: dtype=float64 shape=(8,) val="0x1a670979"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0029_red
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0029_red/angle_deg: dtype=float64 shape=(8,) val="0x400001"
 	@description: type=str val="Angle (deg)"
@@ -5510,8 +5667,6 @@ Generating signature for 161222_16_18_47.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0029_red/pixel_mask_index: dtype=int64 shape=(8,) val="0x4000025"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0029_red/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0029_red/pixel_time_offsets: dtype=float64 shape=(8, 1) val="0x7ff91d94"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0029_red/reference_images/Zstack_Red_0029 -> /acquisition/Zstack_Red_0029
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0029_red/reference_images/reference_images -> /acquisition/Zstack_Red_0029
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0029_red/roi_group_id: dtype=float64 shape=(8,) val="0x400001"
@@ -5535,7 +5690,7 @@ Generating signature for 161222_16_18_47.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0029_red/zoom: dtype=float64 shape=(8,) val="0x1a670979"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0030_green
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0030_green/angle_deg: dtype=float64 shape=(15,) val="0x780001"
 	@description: type=str val="Angle (deg)"
@@ -5557,8 +5712,6 @@ Generating signature for 161222_16_18_47.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0030_green/pixel_mask_index: dtype=int64 shape=(15,) val="0x15b80079"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0030_green/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0030_green/pixel_time_offsets: dtype=float64 shape=(15, 1) val="0x297c358c"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0030_green/reference_images/Zstack_Red_0030 -> /acquisition/Zstack_Red_0030
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0030_green/reference_images/reference_images -> /acquisition/Zstack_Red_0030
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0030_green/roi_group_id: dtype=float64 shape=(15,) val="0x780001"
@@ -5582,7 +5735,7 @@ Generating signature for 161222_16_18_47.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0030_green/zoom: dtype=float64 shape=(15,) val="0x2bd11c2"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0030_red
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0030_red/angle_deg: dtype=float64 shape=(15,) val="0x780001"
 	@description: type=str val="Angle (deg)"
@@ -5604,8 +5757,6 @@ Generating signature for 161222_16_18_47.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0030_red/pixel_mask_index: dtype=int64 shape=(15,) val="0x15b80079"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0030_red/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0030_red/pixel_time_offsets: dtype=float64 shape=(15, 1) val="0x297c358c"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0030_red/reference_images/Zstack_Red_0030 -> /acquisition/Zstack_Red_0030
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0030_red/reference_images/reference_images -> /acquisition/Zstack_Red_0030
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0030_red/roi_group_id: dtype=float64 shape=(15,) val="0x780001"
@@ -5629,7 +5780,7 @@ Generating signature for 161222_16_18_47.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0030_red/zoom: dtype=float64 shape=(15,) val="0x2bd11c2"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0031_green
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0031_green/angle_deg: dtype=float64 shape=(15,) val="0x780001"
 	@description: type=str val="Angle (deg)"
@@ -5651,8 +5802,6 @@ Generating signature for 161222_16_18_47.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0031_green/pixel_mask_index: dtype=int64 shape=(15,) val="0x15b80079"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0031_green/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0031_green/pixel_time_offsets: dtype=float64 shape=(15, 1) val="0x34ee37be"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0031_green/reference_images/Zstack_Red_0031 -> /acquisition/Zstack_Red_0031
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0031_green/reference_images/reference_images -> /acquisition/Zstack_Red_0031
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0031_green/roi_group_id: dtype=float64 shape=(15,) val="0x780001"
@@ -5676,7 +5825,7 @@ Generating signature for 161222_16_18_47.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0031_green/zoom: dtype=float64 shape=(15,) val="0x2bd11c2"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0031_red
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0031_red/angle_deg: dtype=float64 shape=(15,) val="0x780001"
 	@description: type=str val="Angle (deg)"
@@ -5698,8 +5847,6 @@ Generating signature for 161222_16_18_47.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0031_red/pixel_mask_index: dtype=int64 shape=(15,) val="0x15b80079"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0031_red/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0031_red/pixel_time_offsets: dtype=float64 shape=(15, 1) val="0x34ee37be"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0031_red/reference_images/Zstack_Red_0031 -> /acquisition/Zstack_Red_0031
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0031_red/reference_images/reference_images -> /acquisition/Zstack_Red_0031
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0031_red/roi_group_id: dtype=float64 shape=(15,) val="0x780001"
@@ -5723,7 +5870,7 @@ Generating signature for 161222_16_18_47.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0031_red/zoom: dtype=float64 shape=(15,) val="0x2bd11c2"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0032_green
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0032_green/angle_deg: dtype=float64 shape=(15,) val="0x780001"
 	@description: type=str val="Angle (deg)"
@@ -5745,8 +5892,6 @@ Generating signature for 161222_16_18_47.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0032_green/pixel_mask_index: dtype=int64 shape=(15,) val="0x15b80079"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0032_green/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0032_green/pixel_time_offsets: dtype=float64 shape=(15, 1) val="0x41af3568"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0032_green/reference_images/Zstack_Red_0032 -> /acquisition/Zstack_Red_0032
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0032_green/reference_images/reference_images -> /acquisition/Zstack_Red_0032
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0032_green/roi_group_id: dtype=float64 shape=(15,) val="0x780001"
@@ -5770,7 +5915,7 @@ Generating signature for 161222_16_18_47.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0032_green/zoom: dtype=float64 shape=(15,) val="0x2bd11c2"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0032_red
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0032_red/angle_deg: dtype=float64 shape=(15,) val="0x780001"
 	@description: type=str val="Angle (deg)"
@@ -5792,8 +5937,6 @@ Generating signature for 161222_16_18_47.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0032_red/pixel_mask_index: dtype=int64 shape=(15,) val="0x15b80079"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0032_red/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0032_red/pixel_time_offsets: dtype=float64 shape=(15, 1) val="0x41af3568"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0032_red/reference_images/Zstack_Red_0032 -> /acquisition/Zstack_Red_0032
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0032_red/reference_images/reference_images -> /acquisition/Zstack_Red_0032
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0032_red/roi_group_id: dtype=float64 shape=(15,) val="0x780001"
@@ -5817,7 +5960,7 @@ Generating signature for 161222_16_18_47.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0032_red/zoom: dtype=float64 shape=(15,) val="0x2bd11c2"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0033_green
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0033_green/angle_deg: dtype=float64 shape=(5,) val="0x280001"
 	@description: type=str val="Angle (deg)"
@@ -5839,8 +5982,6 @@ Generating signature for 161222_16_18_47.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0033_green/pixel_mask_index: dtype=int64 shape=(5,) val="0x1400010"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0033_green/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0033_green/pixel_time_offsets: dtype=float64 shape=(5, 1) val="0x73f81127"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0033_green/reference_images/Zstack_Red_0033 -> /acquisition/Zstack_Red_0033
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0033_green/reference_images/reference_images -> /acquisition/Zstack_Red_0033
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0033_green/roi_group_id: dtype=float64 shape=(5,) val="0x280001"
@@ -5864,7 +6005,7 @@ Generating signature for 161222_16_18_47.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0033_green/zoom: dtype=float64 shape=(5,) val="0x697305ec"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0033_red
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0033_red/angle_deg: dtype=float64 shape=(5,) val="0x280001"
 	@description: type=str val="Angle (deg)"
@@ -5886,8 +6027,6 @@ Generating signature for 161222_16_18_47.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0033_red/pixel_mask_index: dtype=int64 shape=(5,) val="0x1400010"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0033_red/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0033_red/pixel_time_offsets: dtype=float64 shape=(5, 1) val="0x73f81127"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0033_red/reference_images/Zstack_Red_0033 -> /acquisition/Zstack_Red_0033
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0033_red/reference_images/reference_images -> /acquisition/Zstack_Red_0033
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0033_red/roi_group_id: dtype=float64 shape=(5,) val="0x280001"
@@ -5911,7 +6050,7 @@ Generating signature for 161222_16_18_47.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0033_red/zoom: dtype=float64 shape=(5,) val="0x697305ec"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0034_green
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0034_green/angle_deg: dtype=float64 shape=(6,) val="0x300001"
 	@description: type=str val="Angle (deg)"
@@ -5933,8 +6072,6 @@ Generating signature for 161222_16_18_47.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0034_green/pixel_mask_index: dtype=int64 shape=(6,) val="0x1f00016"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0034_green/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0034_green/pixel_time_offsets: dtype=float64 shape=(6, 1) val="0x1d221689"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0034_green/reference_images/Zstack_Red_0034 -> /acquisition/Zstack_Red_0034
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0034_green/reference_images/reference_images -> /acquisition/Zstack_Red_0034
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0034_green/roi_group_id: dtype=float64 shape=(6,) val="0x300001"
@@ -5958,7 +6095,7 @@ Generating signature for 161222_16_18_47.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0034_green/zoom: dtype=float64 shape=(6,) val="0x9af2071b"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0034_red
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0034_red/angle_deg: dtype=float64 shape=(6,) val="0x300001"
 	@description: type=str val="Angle (deg)"
@@ -5980,8 +6117,6 @@ Generating signature for 161222_16_18_47.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0034_red/pixel_mask_index: dtype=int64 shape=(6,) val="0x1f00016"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0034_red/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0034_red/pixel_time_offsets: dtype=float64 shape=(6, 1) val="0x1d221689"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0034_red/reference_images/Zstack_Red_0034 -> /acquisition/Zstack_Red_0034
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0034_red/reference_images/reference_images -> /acquisition/Zstack_Red_0034
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0034_red/roi_group_id: dtype=float64 shape=(6,) val="0x300001"
@@ -6005,7 +6140,7 @@ Generating signature for 161222_16_18_47.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0034_red/zoom: dtype=float64 shape=(6,) val="0x9af2071b"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0035_green
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0035_green/angle_deg: dtype=float64 shape=(5,) val="0x280001"
 	@description: type=str val="Angle (deg)"
@@ -6027,8 +6162,6 @@ Generating signature for 161222_16_18_47.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0035_green/pixel_mask_index: dtype=int64 shape=(5,) val="0x1400010"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0035_green/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0035_green/pixel_time_offsets: dtype=float64 shape=(5, 1) val="0x57b01072"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0035_green/reference_images/Zstack_Red_0035 -> /acquisition/Zstack_Red_0035
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0035_green/reference_images/reference_images -> /acquisition/Zstack_Red_0035
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0035_green/roi_group_id: dtype=float64 shape=(5,) val="0x280001"
@@ -6052,7 +6185,7 @@ Generating signature for 161222_16_18_47.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0035_green/zoom: dtype=float64 shape=(5,) val="0x697305ec"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0035_red
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0035_red/angle_deg: dtype=float64 shape=(5,) val="0x280001"
 	@description: type=str val="Angle (deg)"
@@ -6074,8 +6207,6 @@ Generating signature for 161222_16_18_47.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0035_red/pixel_mask_index: dtype=int64 shape=(5,) val="0x1400010"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0035_red/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0035_red/pixel_time_offsets: dtype=float64 shape=(5, 1) val="0x57b01072"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0035_red/reference_images/Zstack_Red_0035 -> /acquisition/Zstack_Red_0035
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0035_red/reference_images/reference_images -> /acquisition/Zstack_Red_0035
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0035_red/roi_group_id: dtype=float64 shape=(5,) val="0x280001"
@@ -6099,7 +6230,7 @@ Generating signature for 161222_16_18_47.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0035_red/zoom: dtype=float64 shape=(5,) val="0x697305ec"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0036_green
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0036_green/angle_deg: dtype=float64 shape=(2,) val="0x100001"
 	@description: type=str val="Angle (deg)"
@@ -6121,8 +6252,6 @@ Generating signature for 161222_16_18_47.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0036_green/pixel_mask_index: dtype=int64 shape=(2,) val="0x300004"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0036_green/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0036_green/pixel_time_offsets: dtype=float64 shape=(2, 1) val="0x2f630669"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0036_green/reference_images/Zstack_Red_0036 -> /acquisition/Zstack_Red_0036
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0036_green/reference_images/reference_images -> /acquisition/Zstack_Red_0036
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0036_green/roi_group_id: dtype=float64 shape=(2,) val="0x100001"
@@ -6146,7 +6275,7 @@ Generating signature for 161222_16_18_47.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0036_green/zoom: dtype=float64 shape=(2,) val="0xdc6025f"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0036_red
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0036_red/angle_deg: dtype=float64 shape=(2,) val="0x100001"
 	@description: type=str val="Angle (deg)"
@@ -6168,8 +6297,6 @@ Generating signature for 161222_16_18_47.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0036_red/pixel_mask_index: dtype=int64 shape=(2,) val="0x300004"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0036_red/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0036_red/pixel_time_offsets: dtype=float64 shape=(2, 1) val="0x2f630669"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0036_red/reference_images/Zstack_Red_0036 -> /acquisition/Zstack_Red_0036
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0036_red/reference_images/reference_images -> /acquisition/Zstack_Red_0036
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0036_red/roi_group_id: dtype=float64 shape=(2,) val="0x100001"
@@ -6193,7 +6320,7 @@ Generating signature for 161222_16_18_47.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0036_red/zoom: dtype=float64 shape=(2,) val="0xdc6025f"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0037_green
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0037_green/angle_deg: dtype=float64 shape=(3,) val="0x180001"
 	@description: type=str val="Angle (deg)"
@@ -6215,8 +6342,6 @@ Generating signature for 161222_16_18_47.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0037_green/pixel_mask_index: dtype=int64 shape=(3,) val="0x680007"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0037_green/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0037_green/pixel_time_offsets: dtype=float64 shape=(3, 1) val="0xac680c3d"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0037_green/reference_images/Zstack_Red_0037 -> /acquisition/Zstack_Red_0037
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0037_green/reference_images/reference_images -> /acquisition/Zstack_Red_0037
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0037_green/roi_group_id: dtype=float64 shape=(3,) val="0x180001"
@@ -6240,7 +6365,7 @@ Generating signature for 161222_16_18_47.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0037_green/zoom: dtype=float64 shape=(3,) val="0x22dd038e"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0037_red
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0037_red/angle_deg: dtype=float64 shape=(3,) val="0x180001"
 	@description: type=str val="Angle (deg)"
@@ -6262,8 +6387,6 @@ Generating signature for 161222_16_18_47.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0037_red/pixel_mask_index: dtype=int64 shape=(3,) val="0x680007"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0037_red/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0037_red/pixel_time_offsets: dtype=float64 shape=(3, 1) val="0xac680c3d"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0037_red/reference_images/Zstack_Red_0037 -> /acquisition/Zstack_Red_0037
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0037_red/reference_images/reference_images -> /acquisition/Zstack_Red_0037
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0037_red/roi_group_id: dtype=float64 shape=(3,) val="0x180001"
@@ -6288,9 +6411,10 @@ Generating signature for 161222_16_18_47.nwb
 	@description: type=str val="Zoom"
 /session_description: dtype=object shape=() val="One or two sentences descri...0x65b618d5"
 /session_start_time: dtype=object shape=() val="2016-12-22T15:58:20.230662+...0x6abc066e"
-/specifications/silverlab_extended_schema/0.2/namespace: dtype=object shape=() val="{"namespaces":[{"doc":"Exte...0x5f6a6a92"
-/specifications/silverlab_extended_schema/0.2/silverlab.metadata: dtype=object shape=() val="{"groups":[{"doc":"A place ...0xc0d670ae"
-/specifications/silverlab_extended_schema/0.2/silverlab.ophys: dtype=object shape=() val="{"groups":[{"datasets":[{"s...0xeab28ad7"
+/specifications/silverlab_extended_schema/0.3/namespace: dtype=object shape=() val="{"namespaces":[{"doc":"Exte...0x2db67446"
+/specifications/silverlab_extended_schema/0.3/silverlab.metadata: dtype=object shape=() val="{"groups":[{"doc":"A place ...0x908295e2"
+/specifications/silverlab_extended_schema/0.3/silverlab.ophys: dtype=object shape=() val="{"groups":[{"datasets":[{"s...0xeab28ad7"
+/specifications/silverlab_extended_schema/0.3/silverlab.roi: dtype=object shape=() val="{"groups":[{"datasets":[{"s...0x5c700123"
 /stimulus/presentation/air_puff
 	@comments: type=str val="Delivered 'instantaneously' at the specified times"
 	@description: type=str val="Air puff stimulus"

--- a/tests/data/161222_16_18_47.sig2
+++ b/tests/data/161222_16_18_47.sig2
@@ -6411,10 +6411,6 @@ Generating signature for 161222_16_18_47.nwb
 	@description: type=str val="Zoom"
 /session_description: dtype=object shape=() val="One or two sentences descri...0x65b618d5"
 /session_start_time: dtype=object shape=() val="2016-12-22T15:58:20.230662+...0x6abc066e"
-/specifications/silverlab_extended_schema/0.3/namespace: dtype=object shape=() val="{"namespaces":[{"doc":"Exte...0x2db67446"
-/specifications/silverlab_extended_schema/0.3/silverlab.metadata: dtype=object shape=() val="{"groups":[{"doc":"A place ...0x908295e2"
-/specifications/silverlab_extended_schema/0.3/silverlab.ophys: dtype=object shape=() val="{"groups":[{"datasets":[{"s...0xeab28ad7"
-/specifications/silverlab_extended_schema/0.3/silverlab.roi: dtype=object shape=() val="{"groups":[{"datasets":[{"s...0x5c700123"
 /stimulus/presentation/air_puff
 	@comments: type=str val="Delivered 'instantaneously' at the specified times"
 	@description: type=str val="Air puff stimulus"

--- a/tests/data/170714_22_26_27.sig2
+++ b/tests/data/170714_22_26_27.sig2
@@ -22514,10 +22514,6 @@ Generating signature for 170714_22_26_27.nwb
 	@description: type=str val="Zoom"
 /session_description: dtype=object shape=() val="One or two sentences descri...0x65b618d5"
 /session_start_time: dtype=object shape=() val="2017-07-14T22:30:15.125589+...0x6b110678"
-/specifications/silverlab_extended_schema/0.3/namespace: dtype=object shape=() val="{"namespaces":[{"doc":"Exte...0x2db67446"
-/specifications/silverlab_extended_schema/0.3/silverlab.metadata: dtype=object shape=() val="{"groups":[{"doc":"A place ...0x908295e2"
-/specifications/silverlab_extended_schema/0.3/silverlab.ophys: dtype=object shape=() val="{"groups":[{"datasets":[{"s...0xeab28ad7"
-/specifications/silverlab_extended_schema/0.3/silverlab.roi: dtype=object shape=() val="{"groups":[{"datasets":[{"s...0x5c700123"
 /stimulus/presentation/air_puff
 	@comments: type=str val="Delivered 'instantaneously' at the specified times"
 	@description: type=str val="Air puff stimulus"

--- a/tests/data/170714_22_26_27.sig2
+++ b/tests/data/170714_22_26_27.sig2
@@ -15,6 +15,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_001_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_001_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_001_Green/imaging_plane -> /general/optophysiology/Zstack0139_green
+/acquisition/ROI_001_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x9aa025d"
 /acquisition/ROI_001_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_001_Red
@@ -30,6 +31,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_001_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_001_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_001_Red/imaging_plane -> /general/optophysiology/Zstack0139_red
+/acquisition/ROI_001_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x9aa025d"
 /acquisition/ROI_001_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_002_Green
@@ -45,6 +47,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_002_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_002_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_002_Green/imaging_plane -> /general/optophysiology/Zstack0139_green
+/acquisition/ROI_002_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x1064038b"
 /acquisition/ROI_002_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_002_Red
@@ -60,6 +63,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_002_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_002_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_002_Red/imaging_plane -> /general/optophysiology/Zstack0139_red
+/acquisition/ROI_002_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x1064038b"
 /acquisition/ROI_002_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_003_Green
@@ -75,6 +79,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_003_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_003_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_003_Green/imaging_plane -> /general/optophysiology/Zstack0139_green
+/acquisition/ROI_003_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xc2702bb"
 /acquisition/ROI_003_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_003_Red
@@ -90,6 +95,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_003_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_003_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_003_Red/imaging_plane -> /general/optophysiology/Zstack0139_red
+/acquisition/ROI_003_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xc2702bb"
 /acquisition/ROI_003_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_004_Green
@@ -105,6 +111,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_004_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_004_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_004_Green/imaging_plane -> /general/optophysiology/Zstack0139_green
+/acquisition/ROI_004_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x12e103e9"
 /acquisition/ROI_004_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_004_Red
@@ -120,6 +127,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_004_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_004_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_004_Red/imaging_plane -> /general/optophysiology/Zstack0139_red
+/acquisition/ROI_004_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x12e103e9"
 /acquisition/ROI_004_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_005_Green
@@ -135,6 +143,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_005_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_005_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_005_Green/imaging_plane -> /general/optophysiology/Zstack0139_green
+/acquisition/ROI_005_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xda50319"
 /acquisition/ROI_005_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_005_Red
@@ -150,6 +159,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_005_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_005_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_005_Red/imaging_plane -> /general/optophysiology/Zstack0139_red
+/acquisition/ROI_005_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xda50319"
 /acquisition/ROI_005_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_006_Green
@@ -165,6 +175,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_006_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_006_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_006_Green/imaging_plane -> /general/optophysiology/Zstack0139_green
+/acquisition/ROI_006_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xe6c0349"
 /acquisition/ROI_006_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_006_Red
@@ -180,6 +191,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_006_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_006_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_006_Red/imaging_plane -> /general/optophysiology/Zstack0139_red
+/acquisition/ROI_006_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xe6c0349"
 /acquisition/ROI_006_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_007_Green
@@ -195,6 +207,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_007_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_007_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_007_Green/imaging_plane -> /general/optophysiology/Zstack0139_green
+/acquisition/ROI_007_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x12f003fa"
 /acquisition/ROI_007_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_007_Red
@@ -210,6 +223,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_007_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_007_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_007_Red/imaging_plane -> /general/optophysiology/Zstack0139_red
+/acquisition/ROI_007_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x12f003fa"
 /acquisition/ROI_007_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_008_Green
@@ -225,6 +239,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_008_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_008_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_008_Green/imaging_plane -> /general/optophysiology/Zstack0140_green
+/acquisition/ROI_008_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x12500392"
 /acquisition/ROI_008_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_008_Red
@@ -240,6 +255,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_008_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_008_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_008_Red/imaging_plane -> /general/optophysiology/Zstack0140_red
+/acquisition/ROI_008_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x12500392"
 /acquisition/ROI_008_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_009_Green
@@ -255,6 +271,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_009_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_009_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_009_Green/imaging_plane -> /general/optophysiology/Zstack0140_green
+/acquisition/ROI_009_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xfb2032a"
 /acquisition/ROI_009_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_009_Red
@@ -270,6 +287,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_009_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_009_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_009_Red/imaging_plane -> /general/optophysiology/Zstack0140_red
+/acquisition/ROI_009_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xfb2032a"
 /acquisition/ROI_009_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_010_Green
@@ -285,6 +303,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_010_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_010_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_010_Green/imaging_plane -> /general/optophysiology/Zstack0140_green
+/acquisition/ROI_010_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x121003c1"
 /acquisition/ROI_010_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_010_Red
@@ -300,6 +319,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_010_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_010_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_010_Red/imaging_plane -> /general/optophysiology/Zstack0140_red
+/acquisition/ROI_010_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x121003c1"
 /acquisition/ROI_010_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_011_Green
@@ -315,6 +335,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_011_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_011_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_011_Green/imaging_plane -> /general/optophysiology/Zstack0140_green
+/acquisition/ROI_011_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x166c0458"
 /acquisition/ROI_011_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_011_Red
@@ -330,6 +351,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_011_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_011_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_011_Red/imaging_plane -> /general/optophysiology/Zstack0140_red
+/acquisition/ROI_011_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x166c0458"
 /acquisition/ROI_011_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_012_Green
@@ -345,6 +367,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_012_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_012_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_012_Green/imaging_plane -> /general/optophysiology/Zstack0140_green
+/acquisition/ROI_012_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xdd302f1"
 /acquisition/ROI_012_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_012_Red
@@ -360,6 +383,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_012_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_012_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_012_Red/imaging_plane -> /general/optophysiology/Zstack0140_red
+/acquisition/ROI_012_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xdd302f1"
 /acquisition/ROI_012_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_013_Green
@@ -375,6 +399,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_013_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_013_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_013_Green/imaging_plane -> /general/optophysiology/Zstack0140_green
+/acquisition/ROI_013_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xe320289"
 /acquisition/ROI_013_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_013_Red
@@ -390,6 +415,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_013_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_013_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_013_Red/imaging_plane -> /general/optophysiology/Zstack0140_red
+/acquisition/ROI_013_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xe320289"
 /acquisition/ROI_013_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_014_Green
@@ -405,6 +431,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_014_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_014_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_014_Green/imaging_plane -> /general/optophysiology/Zstack0140_green
+/acquisition/ROI_014_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x10900320"
 /acquisition/ROI_014_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_014_Red
@@ -420,6 +447,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_014_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_014_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_014_Red/imaging_plane -> /general/optophysiology/Zstack0140_red
+/acquisition/ROI_014_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x10900320"
 /acquisition/ROI_014_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_015_Green
@@ -435,6 +463,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_015_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_015_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_015_Green/imaging_plane -> /general/optophysiology/Zstack0141_green
+/acquisition/ROI_015_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xff002b8"
 /acquisition/ROI_015_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_015_Red
@@ -450,6 +479,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_015_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_015_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_015_Red/imaging_plane -> /general/optophysiology/Zstack0141_red
+/acquisition/ROI_015_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xff002b8"
 /acquisition/ROI_015_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_016_Green
@@ -465,6 +495,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_016_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_016_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_016_Green/imaging_plane -> /general/optophysiology/Zstack0141_green
+/acquisition/ROI_016_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xf51034f"
 /acquisition/ROI_016_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_016_Red
@@ -480,6 +511,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_016_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_016_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_016_Red/imaging_plane -> /general/optophysiology/Zstack0141_red
+/acquisition/ROI_016_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xf51034f"
 /acquisition/ROI_016_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_017_Green
@@ -495,6 +527,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_017_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_017_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_017_Green/imaging_plane -> /general/optophysiology/Zstack0141_green
+/acquisition/ROI_017_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x12b603e7"
 /acquisition/ROI_017_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_017_Red
@@ -510,6 +543,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_017_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_017_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_017_Red/imaging_plane -> /general/optophysiology/Zstack0141_red
+/acquisition/ROI_017_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x12b603e7"
 /acquisition/ROI_017_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_018_Green
@@ -525,6 +559,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_018_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_018_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_018_Green/imaging_plane -> /general/optophysiology/Zstack0141_green
+/acquisition/ROI_018_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xf19037f"
 /acquisition/ROI_018_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_018_Red
@@ -540,6 +575,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_018_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_018_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_018_Red/imaging_plane -> /general/optophysiology/Zstack0141_red
+/acquisition/ROI_018_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xf19037f"
 /acquisition/ROI_018_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_019_Green
@@ -555,6 +591,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_019_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_019_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_019_Green/imaging_plane -> /general/optophysiology/Zstack0141_green
+/acquisition/ROI_019_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xe790317"
 /acquisition/ROI_019_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_019_Red
@@ -570,6 +607,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_019_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_019_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_019_Red/imaging_plane -> /general/optophysiology/Zstack0141_red
+/acquisition/ROI_019_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xe790317"
 /acquisition/ROI_019_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_020_Green
@@ -585,6 +623,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_020_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_020_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_020_Green/imaging_plane -> /general/optophysiology/Zstack0141_green
+/acquisition/ROI_020_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x10d703ae"
 /acquisition/ROI_020_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_020_Red
@@ -600,6 +639,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_020_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_020_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_020_Red/imaging_plane -> /general/optophysiology/Zstack0141_red
+/acquisition/ROI_020_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x10d703ae"
 /acquisition/ROI_020_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_021_Green
@@ -615,6 +655,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_021_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_021_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_021_Green/imaging_plane -> /general/optophysiology/Zstack0142_green
+/acquisition/ROI_021_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x15330445"
 /acquisition/ROI_021_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_021_Red
@@ -630,6 +671,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_021_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_021_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_021_Red/imaging_plane -> /general/optophysiology/Zstack0142_red
+/acquisition/ROI_021_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x15330445"
 /acquisition/ROI_021_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_022_Green
@@ -645,6 +687,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_022_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_022_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_022_Green/imaging_plane -> /general/optophysiology/Zstack0142_green
+/acquisition/ROI_022_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xc9a02de"
 /acquisition/ROI_022_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_022_Red
@@ -660,6 +703,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_022_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_022_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_022_Red/imaging_plane -> /general/optophysiology/Zstack0142_red
+/acquisition/ROI_022_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xc9a02de"
 /acquisition/ROI_022_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_023_Green
@@ -675,6 +719,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_023_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_023_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_023_Green/imaging_plane -> /general/optophysiology/Zstack0142_green
+/acquisition/ROI_023_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x16f10474"
 /acquisition/ROI_023_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_023_Red
@@ -690,6 +735,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_023_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_023_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_023_Red/imaging_plane -> /general/optophysiology/Zstack0142_red
+/acquisition/ROI_023_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x16f10474"
 /acquisition/ROI_023_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_024_Green
@@ -705,6 +751,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_024_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_024_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_024_Green/imaging_plane -> /general/optophysiology/Zstack0142_green
+/acquisition/ROI_024_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x141903cd"
 /acquisition/ROI_024_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_024_Red
@@ -720,6 +767,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_024_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_024_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_024_Red/imaging_plane -> /general/optophysiology/Zstack0142_red
+/acquisition/ROI_024_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x141903cd"
 /acquisition/ROI_024_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_025_Green
@@ -735,6 +783,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_025_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_025_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_025_Green/imaging_plane -> /general/optophysiology/Zstack0142_green
+/acquisition/ROI_025_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x13460418"
 /acquisition/ROI_025_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_025_Red
@@ -750,6 +799,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_025_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_025_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_025_Red/imaging_plane -> /general/optophysiology/Zstack0142_red
+/acquisition/ROI_025_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x13460418"
 /acquisition/ROI_025_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_026_Green
@@ -765,6 +815,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_026_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_026_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_026_Green/imaging_plane -> /general/optophysiology/Zstack0143_green
+/acquisition/ROI_026_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x4860167"
 /acquisition/ROI_026_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_026_Red
@@ -780,6 +831,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_026_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_026_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_026_Red/imaging_plane -> /general/optophysiology/Zstack0143_red
+/acquisition/ROI_026_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x4860167"
 /acquisition/ROI_026_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_027_Green
@@ -795,6 +847,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_027_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_027_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_027_Green/imaging_plane -> /general/optophysiology/Zstack0143_green
+/acquisition/ROI_027_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xbac02b1"
 /acquisition/ROI_027_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_027_Red
@@ -810,6 +863,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_027_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_027_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_027_Red/imaging_plane -> /general/optophysiology/Zstack0143_red
+/acquisition/ROI_027_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xbac02b1"
 /acquisition/ROI_027_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_028_Green
@@ -825,6 +879,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_028_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_028_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_028_Green/imaging_plane -> /general/optophysiology/Zstack0143_green
+/acquisition/ROI_028_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xedd02fd"
 /acquisition/ROI_028_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_028_Red
@@ -840,6 +895,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_028_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_028_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_028_Red/imaging_plane -> /general/optophysiology/Zstack0143_red
+/acquisition/ROI_028_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xedd02fd"
 /acquisition/ROI_028_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_029_Green
@@ -855,6 +911,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_029_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_029_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_029_Green/imaging_plane -> /general/optophysiology/Zstack0143_green
+/acquisition/ROI_029_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x10080348"
 /acquisition/ROI_029_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_029_Red
@@ -870,6 +927,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_029_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_029_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_029_Red/imaging_plane -> /general/optophysiology/Zstack0143_red
+/acquisition/ROI_029_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x10080348"
 /acquisition/ROI_029_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_030_Green
@@ -885,6 +943,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_030_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_030_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_030_Green/imaging_plane -> /general/optophysiology/Zstack0143_green
+/acquisition/ROI_030_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x13390394"
 /acquisition/ROI_030_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_030_Red
@@ -900,6 +959,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_030_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_030_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_030_Red/imaging_plane -> /general/optophysiology/Zstack0143_red
+/acquisition/ROI_030_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x13390394"
 /acquisition/ROI_030_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_031_Green
@@ -915,6 +975,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_031_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_031_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_031_Green/imaging_plane -> /general/optophysiology/Zstack0122_green
+/acquisition/ROI_031_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xd7202e1"
 /acquisition/ROI_031_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_031_Red
@@ -930,6 +991,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_031_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_031_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_031_Red/imaging_plane -> /general/optophysiology/Zstack0122_red
+/acquisition/ROI_031_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xd7202e1"
 /acquisition/ROI_031_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_032_Green
@@ -945,6 +1007,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_032_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_032_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_032_Green/imaging_plane -> /general/optophysiology/Zstack0122_green
+/acquisition/ROI_032_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x129a042b"
 /acquisition/ROI_032_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_032_Red
@@ -960,6 +1023,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_032_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_032_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_032_Red/imaging_plane -> /general/optophysiology/Zstack0122_red
+/acquisition/ROI_032_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x129a042b"
 /acquisition/ROI_032_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_033_Green
@@ -975,6 +1039,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_033_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_033_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_033_Green/imaging_plane -> /general/optophysiology/Zstack0122_green
+/acquisition/ROI_033_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x11ce0378"
 /acquisition/ROI_033_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_033_Red
@@ -990,6 +1055,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_033_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_033_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_033_Red/imaging_plane -> /general/optophysiology/Zstack0122_red
+/acquisition/ROI_033_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x11ce0378"
 /acquisition/ROI_033_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_034_Green
@@ -1005,6 +1071,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_034_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_034_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_034_Green/imaging_plane -> /general/optophysiology/Zstack0122_green
+/acquisition/ROI_034_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x17f504c2"
 /acquisition/ROI_034_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_034_Red
@@ -1020,6 +1087,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_034_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_034_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_034_Red/imaging_plane -> /general/optophysiology/Zstack0122_red
+/acquisition/ROI_034_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x17f504c2"
 /acquisition/ROI_034_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_035_Green
@@ -1035,6 +1103,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_035_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_035_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_035_Green/imaging_plane -> /general/optophysiology/Zstack0122_green
+/acquisition/ROI_035_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xe310310"
 /acquisition/ROI_035_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_035_Red
@@ -1050,6 +1119,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_035_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_035_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_035_Red/imaging_plane -> /general/optophysiology/Zstack0122_red
+/acquisition/ROI_035_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xe310310"
 /acquisition/ROI_035_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_036_Green
@@ -1065,6 +1135,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_036_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_036_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_036_Green/imaging_plane -> /general/optophysiology/Zstack0122_green
+/acquisition/ROI_036_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x1458045a"
 /acquisition/ROI_036_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_036_Red
@@ -1080,6 +1151,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_036_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_036_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_036_Red/imaging_plane -> /general/optophysiology/Zstack0122_red
+/acquisition/ROI_036_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x1458045a"
 /acquisition/ROI_036_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_037_Green
@@ -1095,6 +1167,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_037_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_037_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_037_Green/imaging_plane -> /general/optophysiology/Zstack0122_green
+/acquisition/ROI_037_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x138c03a7"
 /acquisition/ROI_037_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_037_Red
@@ -1110,6 +1183,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_037_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_037_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_037_Red/imaging_plane -> /general/optophysiology/Zstack0122_red
+/acquisition/ROI_037_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x138c03a7"
 /acquisition/ROI_037_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_038_Green
@@ -1125,6 +1199,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_038_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_038_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_038_Green/imaging_plane -> /general/optophysiology/Zstack0122_green
+/acquisition/ROI_038_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x18b404f1"
 /acquisition/ROI_038_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_038_Red
@@ -1140,6 +1215,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_038_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_038_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_038_Red/imaging_plane -> /general/optophysiology/Zstack0122_red
+/acquisition/ROI_038_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x18b404f1"
 /acquisition/ROI_038_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_039_Green
@@ -1155,6 +1231,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_039_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_039_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_039_Green/imaging_plane -> /general/optophysiology/Zstack0122_green
+/acquisition/ROI_039_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xfef033f"
 /acquisition/ROI_039_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_039_Red
@@ -1170,6 +1247,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_039_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_039_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_039_Red/imaging_plane -> /general/optophysiology/Zstack0122_red
+/acquisition/ROI_039_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xfef033f"
 /acquisition/ROI_039_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_040_Green
@@ -1185,6 +1263,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_040_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_040_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_040_Green/imaging_plane -> /general/optophysiology/Zstack0122_green
+/acquisition/ROI_040_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x1221038b"
 /acquisition/ROI_040_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_040_Red
@@ -1200,6 +1279,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_040_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_040_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_040_Red/imaging_plane -> /general/optophysiology/Zstack0122_red
+/acquisition/ROI_040_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x1221038b"
 /acquisition/ROI_040_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_041_Green
@@ -1215,6 +1295,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_041_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_041_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_041_Green/imaging_plane -> /general/optophysiology/Zstack0064_green
+/acquisition/ROI_041_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xd5102d7"
 /acquisition/ROI_041_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_041_Red
@@ -1230,6 +1311,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_041_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_041_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_041_Red/imaging_plane -> /general/optophysiology/Zstack0064_red
+/acquisition/ROI_041_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xd5102d7"
 /acquisition/ROI_041_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_042_Green
@@ -1245,6 +1327,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_042_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_042_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_042_Green/imaging_plane -> /general/optophysiology/Zstack0064_green
+/acquisition/ROI_042_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xf830323"
 /acquisition/ROI_042_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_042_Red
@@ -1260,6 +1343,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_042_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_042_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_042_Red/imaging_plane -> /general/optophysiology/Zstack0064_red
+/acquisition/ROI_042_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xf830323"
 /acquisition/ROI_042_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_043_Green
@@ -1275,6 +1359,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_043_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_043_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_043_Green/imaging_plane -> /general/optophysiology/Zstack0064_green
+/acquisition/ROI_043_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xfaf036e"
 /acquisition/ROI_043_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_043_Red
@@ -1290,6 +1375,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_043_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_043_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_043_Red/imaging_plane -> /general/optophysiology/Zstack0064_red
+/acquisition/ROI_043_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xfaf036e"
 /acquisition/ROI_043_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_044_Green
@@ -1305,6 +1391,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_044_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_044_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_044_Green/imaging_plane -> /general/optophysiology/Zstack0064_green
+/acquisition/ROI_044_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xbe602bb"
 /acquisition/ROI_044_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_044_Red
@@ -1320,6 +1407,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_044_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_044_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_044_Red/imaging_plane -> /general/optophysiology/Zstack0064_red
+/acquisition/ROI_044_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xbe602bb"
 /acquisition/ROI_044_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_045_Green
@@ -1335,6 +1423,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_045_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_045_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_045_Green/imaging_plane -> /general/optophysiology/Zstack0064_green
+/acquisition/ROI_045_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xf0f0306"
 /acquisition/ROI_045_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_045_Red
@@ -1350,6 +1439,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_045_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_045_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_045_Red/imaging_plane -> /general/optophysiology/Zstack0064_red
+/acquisition/ROI_045_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xf0f0306"
 /acquisition/ROI_045_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_046_Green
@@ -1365,6 +1455,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_046_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_046_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_046_Green/imaging_plane -> /general/optophysiology/Zstack0064_green
+/acquisition/ROI_046_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x163d0451"
 /acquisition/ROI_046_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_046_Red
@@ -1380,6 +1471,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_046_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_046_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_046_Red/imaging_plane -> /general/optophysiology/Zstack0064_red
+/acquisition/ROI_046_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x163d0451"
 /acquisition/ROI_046_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_047_Green
@@ -1395,6 +1487,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_047_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_047_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_047_Green/imaging_plane -> /general/optophysiology/Zstack0064_green
+/acquisition/ROI_047_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x1669049c"
 /acquisition/ROI_047_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_047_Red
@@ -1410,6 +1503,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_047_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_047_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_047_Red/imaging_plane -> /general/optophysiology/Zstack0064_red
+/acquisition/ROI_047_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x1669049c"
 /acquisition/ROI_047_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_048_Green
@@ -1425,6 +1519,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_048_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_048_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_048_Green/imaging_plane -> /general/optophysiology/Zstack0064_green
+/acquisition/ROI_048_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xda402ea"
 /acquisition/ROI_048_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_048_Red
@@ -1440,6 +1535,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_048_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_048_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_048_Red/imaging_plane -> /general/optophysiology/Zstack0064_red
+/acquisition/ROI_048_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xda402ea"
 /acquisition/ROI_048_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_049_Green
@@ -1455,6 +1551,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_049_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_049_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_049_Green/imaging_plane -> /general/optophysiology/Zstack0064_green
+/acquisition/ROI_049_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x12d40435"
 /acquisition/ROI_049_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_049_Red
@@ -1470,6 +1567,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_049_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_049_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_049_Red/imaging_plane -> /general/optophysiology/Zstack0064_red
+/acquisition/ROI_049_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x12d40435"
 /acquisition/ROI_049_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_050_Green
@@ -1485,6 +1583,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_050_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_050_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_050_Green/imaging_plane -> /general/optophysiology/Zstack0064_green
+/acquisition/ROI_050_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x12000381"
 /acquisition/ROI_050_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_050_Red
@@ -1500,6 +1599,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_050_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_050_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_050_Red/imaging_plane -> /general/optophysiology/Zstack0064_red
+/acquisition/ROI_050_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x12000381"
 /acquisition/ROI_050_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_051_Green
@@ -1515,6 +1615,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_051_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_051_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_051_Green/imaging_plane -> /general/optophysiology/Zstack0067_green
+/acquisition/ROI_051_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x182f04cc"
 /acquisition/ROI_051_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_051_Red
@@ -1530,6 +1631,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_051_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_051_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_051_Red/imaging_plane -> /general/optophysiology/Zstack0067_red
+/acquisition/ROI_051_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x182f04cc"
 /acquisition/ROI_051_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_052_Green
@@ -1545,6 +1647,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_052_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_052_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_052_Green/imaging_plane -> /general/optophysiology/Zstack0067_green
+/acquisition/ROI_052_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xe630319"
 /acquisition/ROI_052_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_052_Red
@@ -1560,6 +1663,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_052_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_052_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_052_Red/imaging_plane -> /general/optophysiology/Zstack0067_red
+/acquisition/ROI_052_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xe630319"
 /acquisition/ROI_052_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_053_Green
@@ -1575,6 +1679,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_053_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_053_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_053_Green/imaging_plane -> /general/optophysiology/Zstack0067_green
+/acquisition/ROI_053_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x10950365"
 /acquisition/ROI_053_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_053_Red
@@ -1590,6 +1695,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_053_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_053_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_053_Red/imaging_plane -> /general/optophysiology/Zstack0067_red
+/acquisition/ROI_053_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x10950365"
 /acquisition/ROI_053_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_054_Green
@@ -1605,6 +1711,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_054_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_054_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_054_Green/imaging_plane -> /general/optophysiology/Zstack0067_green
+/acquisition/ROI_054_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x13be03b0"
 /acquisition/ROI_054_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_054_Red
@@ -1620,6 +1727,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_054_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_054_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_054_Red/imaging_plane -> /general/optophysiology/Zstack0067_red
+/acquisition/ROI_054_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x13be03b0"
 /acquisition/ROI_054_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_055_Green
@@ -1635,6 +1743,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_055_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_055_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_055_Green/imaging_plane -> /general/optophysiology/Zstack0067_green
+/acquisition/ROI_055_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x14f103fc"
 /acquisition/ROI_055_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_055_Red
@@ -1650,6 +1759,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_055_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_055_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_055_Red/imaging_plane -> /general/optophysiology/Zstack0067_red
+/acquisition/ROI_055_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x14f103fc"
 /acquisition/ROI_055_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_056_Green
@@ -1665,6 +1775,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_056_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_056_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_056_Green/imaging_plane -> /general/optophysiology/Zstack0067_green
+/acquisition/ROI_056_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x10210348"
 /acquisition/ROI_056_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_056_Red
@@ -1680,6 +1791,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_056_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_056_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_056_Red/imaging_plane -> /general/optophysiology/Zstack0067_red
+/acquisition/ROI_056_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x10210348"
 /acquisition/ROI_056_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_057_Green
@@ -1695,6 +1807,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_057_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_057_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_057_Green/imaging_plane -> /general/optophysiology/Zstack0067_green
+/acquisition/ROI_057_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x10550394"
 /acquisition/ROI_057_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_057_Red
@@ -1710,6 +1823,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_057_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_057_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_057_Red/imaging_plane -> /general/optophysiology/Zstack0067_red
+/acquisition/ROI_057_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x10550394"
 /acquisition/ROI_057_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_058_Green
@@ -1725,6 +1839,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_058_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_058_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_058_Green/imaging_plane -> /general/optophysiology/Zstack0067_green
+/acquisition/ROI_058_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xfc2033f"
 /acquisition/ROI_058_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_058_Red
@@ -1740,6 +1855,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_058_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_058_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_058_Red/imaging_plane -> /general/optophysiology/Zstack0067_red
+/acquisition/ROI_058_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xfc2033f"
 /acquisition/ROI_058_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_059_Green
@@ -1755,6 +1871,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_059_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_059_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_059_Green/imaging_plane -> /general/optophysiology/Zstack0067_green
+/acquisition/ROI_059_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xd5a02e5"
 /acquisition/ROI_059_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_059_Red
@@ -1770,6 +1887,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_059_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_059_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_059_Red/imaging_plane -> /general/optophysiology/Zstack0067_red
+/acquisition/ROI_059_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xd5a02e5"
 /acquisition/ROI_059_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_060_Green
@@ -1785,6 +1903,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_060_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_060_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_060_Green/imaging_plane -> /general/optophysiology/Zstack0080_green
+/acquisition/ROI_060_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x16e80489"
 /acquisition/ROI_060_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_060_Red
@@ -1800,6 +1919,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_060_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_060_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_060_Red/imaging_plane -> /general/optophysiology/Zstack0080_red
+/acquisition/ROI_060_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x16e80489"
 /acquisition/ROI_060_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_061_Green
@@ -1815,6 +1935,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_061_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_061_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_061_Green/imaging_plane -> /general/optophysiology/Zstack0080_green
+/acquisition/ROI_061_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x178b0490"
 /acquisition/ROI_061_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_061_Red
@@ -1830,6 +1951,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_061_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_061_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_061_Red/imaging_plane -> /general/optophysiology/Zstack0080_red
+/acquisition/ROI_061_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x178b0490"
 /acquisition/ROI_061_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_062_Green
@@ -1845,6 +1967,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_062_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_062_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_062_Green/imaging_plane -> /general/optophysiology/Zstack0080_green
+/acquisition/ROI_062_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x15230436"
 /acquisition/ROI_062_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_062_Red
@@ -1860,6 +1983,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_062_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_062_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_062_Red/imaging_plane -> /general/optophysiology/Zstack0080_red
+/acquisition/ROI_062_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x15230436"
 /acquisition/ROI_062_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_063_Green
@@ -1875,6 +1999,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_063_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_063_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_063_Green/imaging_plane -> /general/optophysiology/Zstack0080_green
+/acquisition/ROI_063_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x11c403dd"
 /acquisition/ROI_063_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_063_Red
@@ -1890,6 +2015,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_063_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_063_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_063_Red/imaging_plane -> /general/optophysiology/Zstack0080_red
+/acquisition/ROI_063_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x11c403dd"
 /acquisition/ROI_063_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_064_Green
@@ -1905,6 +2031,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_064_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_064_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_064_Green/imaging_plane -> /general/optophysiology/Zstack0080_green
+/acquisition/ROI_064_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xf5c0383"
 /acquisition/ROI_064_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_064_Red
@@ -1920,6 +2047,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_064_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_064_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_064_Red/imaging_plane -> /general/optophysiology/Zstack0080_red
+/acquisition/ROI_064_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xf5c0383"
 /acquisition/ROI_064_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_065_Green
@@ -1935,6 +2063,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_065_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_065_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_065_Green/imaging_plane -> /general/optophysiology/Zstack0087_green
+/acquisition/ROI_065_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xef20329"
 /acquisition/ROI_065_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_065_Red
@@ -1950,6 +2079,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_065_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_065_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_065_Red/imaging_plane -> /general/optophysiology/Zstack0087_red
+/acquisition/ROI_065_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xef20329"
 /acquisition/ROI_065_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_066_Green
@@ -1965,6 +2095,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_066_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_066_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_066_Green/imaging_plane -> /general/optophysiology/Zstack0087_green
+/acquisition/ROI_066_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x118e03cf"
 /acquisition/ROI_066_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_066_Red
@@ -1980,6 +2111,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_066_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_066_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_066_Red/imaging_plane -> /general/optophysiology/Zstack0087_red
+/acquisition/ROI_066_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x118e03cf"
 /acquisition/ROI_066_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_067_Green
@@ -1995,6 +2127,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_067_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_067_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_067_Green/imaging_plane -> /general/optophysiology/Zstack0087_green
+/acquisition/ROI_067_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xf260375"
 /acquisition/ROI_067_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_067_Red
@@ -2010,6 +2143,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_067_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_067_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_067_Red/imaging_plane -> /general/optophysiology/Zstack0087_red
+/acquisition/ROI_067_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xf260375"
 /acquisition/ROI_067_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_068_Green
@@ -2025,6 +2159,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_068_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_068_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_068_Green/imaging_plane -> /general/optophysiology/Zstack0087_green
+/acquisition/ROI_068_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x13b8041a"
 /acquisition/ROI_068_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_068_Red
@@ -2040,6 +2175,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_068_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_068_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_068_Red/imaging_plane -> /general/optophysiology/Zstack0087_red
+/acquisition/ROI_068_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x13b8041a"
 /acquisition/ROI_068_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_069_Green
@@ -2055,6 +2191,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_069_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_069_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_069_Green/imaging_plane -> /general/optophysiology/Zstack0110_green
+/acquisition/ROI_069_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xe5202c1"
 /acquisition/ROI_069_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_069_Red
@@ -2070,6 +2207,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_069_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_069_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_069_Red/imaging_plane -> /general/optophysiology/Zstack0110_red
+/acquisition/ROI_069_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xe5202c1"
 /acquisition/ROI_069_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_070_Green
@@ -2085,6 +2223,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_070_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_070_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_070_Green/imaging_plane -> /general/optophysiology/Zstack0110_green
+/acquisition/ROI_070_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x16e90466"
 /acquisition/ROI_070_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_070_Red
@@ -2100,6 +2239,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_070_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_070_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_070_Red/imaging_plane -> /general/optophysiology/Zstack0110_red
+/acquisition/ROI_070_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x16e90466"
 /acquisition/ROI_070_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_071_Green
@@ -2115,6 +2255,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_071_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_071_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_071_Green/imaging_plane -> /general/optophysiology/Zstack0110_green
+/acquisition/ROI_071_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x1382040c"
 /acquisition/ROI_071_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_071_Red
@@ -2130,6 +2271,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_071_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_071_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_071_Red/imaging_plane -> /general/optophysiology/Zstack0110_red
+/acquisition/ROI_071_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x1382040c"
 /acquisition/ROI_071_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_072_Green
@@ -2145,6 +2287,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_072_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_072_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_072_Green/imaging_plane -> /general/optophysiology/Zstack0111_green
+/acquisition/ROI_072_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x101b03b2"
 /acquisition/ROI_072_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_072_Red
@@ -2160,6 +2303,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_072_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_072_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_072_Red/imaging_plane -> /general/optophysiology/Zstack0111_red
+/acquisition/ROI_072_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x101b03b2"
 /acquisition/ROI_072_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_073_Green
@@ -2175,6 +2319,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_073_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_073_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_073_Green/imaging_plane -> /general/optophysiology/Zstack0111_green
+/acquisition/ROI_073_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xab50259"
 /acquisition/ROI_073_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_073_Red
@@ -2190,6 +2335,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_073_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_073_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_073_Red/imaging_plane -> /general/optophysiology/Zstack0111_red
+/acquisition/ROI_073_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xab50259"
 /acquisition/ROI_073_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_074_Green
@@ -2205,6 +2351,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_074_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_074_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_074_Green/imaging_plane -> /general/optophysiology/Zstack0111_green
+/acquisition/ROI_074_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x134c03fe"
 /acquisition/ROI_074_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_074_Red
@@ -2220,6 +2367,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_074_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_074_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_074_Red/imaging_plane -> /general/optophysiology/Zstack0111_red
+/acquisition/ROI_074_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x134c03fe"
 /acquisition/ROI_074_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_075_Green
@@ -2235,6 +2383,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_075_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_075_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_075_Green/imaging_plane -> /general/optophysiology/Zstack0111_green
+/acquisition/ROI_075_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x10e403a4"
 /acquisition/ROI_075_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_075_Red
@@ -2250,6 +2399,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_075_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_075_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_075_Red/imaging_plane -> /general/optophysiology/Zstack0111_red
+/acquisition/ROI_075_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x10e403a4"
 /acquisition/ROI_075_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_076_Green
@@ -2265,6 +2415,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_076_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_076_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_076_Green/imaging_plane -> /general/optophysiology/Zstack0111_green
+/acquisition/ROI_076_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x15760449"
 /acquisition/ROI_076_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_076_Red
@@ -2280,6 +2431,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_076_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_076_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_076_Red/imaging_plane -> /general/optophysiology/Zstack0111_red
+/acquisition/ROI_076_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x15760449"
 /acquisition/ROI_076_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_077_Green
@@ -2295,6 +2447,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_077_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_077_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_077_Green/imaging_plane -> /general/optophysiology/Zstack0111_green
+/acquisition/ROI_077_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xf1902f1"
 /acquisition/ROI_077_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_077_Red
@@ -2310,6 +2463,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_077_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_077_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_077_Red/imaging_plane -> /general/optophysiology/Zstack0111_red
+/acquisition/ROI_077_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xf1902f1"
 /acquisition/ROI_077_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_078_Green
@@ -2325,6 +2479,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_078_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_078_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_078_Green/imaging_plane -> /general/optophysiology/Zstack0120_green
+/acquisition/ROI_078_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x17a80495"
 /acquisition/ROI_078_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_078_Red
@@ -2340,6 +2495,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_078_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_078_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_078_Red/imaging_plane -> /general/optophysiology/Zstack0120_red
+/acquisition/ROI_078_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x17a80495"
 /acquisition/ROI_078_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_079_Green
@@ -2355,6 +2511,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_079_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_079_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_079_Green/imaging_plane -> /general/optophysiology/Zstack0120_green
+/acquisition/ROI_079_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x1540043b"
 /acquisition/ROI_079_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_079_Red
@@ -2370,6 +2527,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_079_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_079_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_079_Red/imaging_plane -> /general/optophysiology/Zstack0120_red
+/acquisition/ROI_079_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x1540043b"
 /acquisition/ROI_079_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_080_Green
@@ -2385,6 +2543,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_080_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_080_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_080_Green/imaging_plane -> /general/optophysiology/Zstack0139_green
+/acquisition/ROI_080_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x11d903e1"
 /acquisition/ROI_080_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_080_Red
@@ -2400,6 +2559,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_080_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_080_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_080_Red/imaging_plane -> /general/optophysiology/Zstack0139_red
+/acquisition/ROI_080_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x11d903e1"
 /acquisition/ROI_080_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_081_Green
@@ -2415,6 +2575,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_081_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_081_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_081_Green/imaging_plane -> /general/optophysiology/Zstack0139_green
+/acquisition/ROI_081_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xf790388"
 /acquisition/ROI_081_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_081_Red
@@ -2430,6 +2591,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_081_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_081_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_081_Red/imaging_plane -> /general/optophysiology/Zstack0139_red
+/acquisition/ROI_081_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xf790388"
 /acquisition/ROI_081_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_082_Green
@@ -2445,6 +2607,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_082_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_082_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_082_Green/imaging_plane -> /general/optophysiology/Zstack0139_green
+/acquisition/ROI_082_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x4180130"
 /acquisition/ROI_082_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_082_Red
@@ -2460,6 +2623,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_082_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_082_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_082_Red/imaging_plane -> /general/optophysiology/Zstack0139_red
+/acquisition/ROI_082_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x4180130"
 /acquisition/ROI_082_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_083_Green
@@ -2475,6 +2639,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_083_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_083_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_083_Green/imaging_plane -> /general/optophysiology/Zstack0152_green
+/acquisition/ROI_083_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x11a303d3"
 /acquisition/ROI_083_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_083_Red
@@ -2490,6 +2655,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_083_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_083_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_083_Red/imaging_plane -> /general/optophysiology/Zstack0152_red
+/acquisition/ROI_083_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x11a303d3"
 /acquisition/ROI_083_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_084_Green
@@ -2505,6 +2671,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_084_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_084_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_084_Green/imaging_plane -> /general/optophysiology/Zstack0132_green
+/acquisition/ROI_084_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xf43037a"
 /acquisition/ROI_084_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_084_Red
@@ -2520,6 +2687,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_084_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_084_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_084_Red/imaging_plane -> /general/optophysiology/Zstack0132_red
+/acquisition/ROI_084_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xf43037a"
 /acquisition/ROI_084_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_085_Green
@@ -2535,6 +2703,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_085_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_085_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_085_Green/imaging_plane -> /general/optophysiology/Zstack0132_green
+/acquisition/ROI_085_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x13d5041f"
 /acquisition/ROI_085_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_085_Red
@@ -2550,6 +2719,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_085_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_085_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_085_Red/imaging_plane -> /general/optophysiology/Zstack0132_red
+/acquisition/ROI_085_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x13d5041f"
 /acquisition/ROI_085_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_086_Green
@@ -2565,6 +2735,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_086_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_086_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_086_Green/imaging_plane -> /general/optophysiology/Zstack0132_green
+/acquisition/ROI_086_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xe6f02c6"
 /acquisition/ROI_086_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_086_Red
@@ -2580,6 +2751,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_086_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_086_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_086_Red/imaging_plane -> /general/optophysiology/Zstack0132_red
+/acquisition/ROI_086_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xe6f02c6"
 /acquisition/ROI_086_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_087_Green
@@ -2595,6 +2767,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_087_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_087_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_087_Green/imaging_plane -> /general/optophysiology/Zstack0132_green
+/acquisition/ROI_087_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x16fe046a"
 /acquisition/ROI_087_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_087_Red
@@ -2610,6 +2783,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_087_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_087_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_087_Red/imaging_plane -> /general/optophysiology/Zstack0132_red
+/acquisition/ROI_087_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x16fe046a"
 /acquisition/ROI_087_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_088_Green
@@ -2625,6 +2799,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_088_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_088_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_088_Green/imaging_plane -> /general/optophysiology/Zstack0132_green
+/acquisition/ROI_088_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x139f0411"
 /acquisition/ROI_088_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_088_Red
@@ -2640,6 +2815,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_088_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_088_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_088_Red/imaging_plane -> /general/optophysiology/Zstack0132_red
+/acquisition/ROI_088_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x139f0411"
 /acquisition/ROI_088_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_089_Green
@@ -2655,6 +2831,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_089_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_089_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_089_Green/imaging_plane -> /general/optophysiology/Zstack0132_green
+/acquisition/ROI_089_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x103803b7"
 /acquisition/ROI_089_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_089_Red
@@ -2670,6 +2847,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_089_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_089_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_089_Red/imaging_plane -> /general/optophysiology/Zstack0132_red
+/acquisition/ROI_089_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x103803b7"
 /acquisition/ROI_089_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_090_Green
@@ -2685,6 +2863,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_090_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_090_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_090_Green/imaging_plane -> /general/optophysiology/Zstack0132_green
+/acquisition/ROI_090_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xad2025e"
 /acquisition/ROI_090_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_090_Red
@@ -2700,6 +2879,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_090_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_090_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_090_Red/imaging_plane -> /general/optophysiology/Zstack0132_red
+/acquisition/ROI_090_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xad2025e"
 /acquisition/ROI_090_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_091_Green
@@ -2715,6 +2895,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_091_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_091_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_091_Green/imaging_plane -> /general/optophysiology/Zstack0132_green
+/acquisition/ROI_091_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x13610402"
 /acquisition/ROI_091_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_091_Red
@@ -2730,6 +2911,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_091_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_091_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_091_Red/imaging_plane -> /general/optophysiology/Zstack0132_red
+/acquisition/ROI_091_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x13610402"
 /acquisition/ROI_091_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_092_Green
@@ -2745,6 +2927,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_092_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_092_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_092_Green/imaging_plane -> /general/optophysiology/Zstack0132_green
+/acquisition/ROI_092_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x110103a9"
 /acquisition/ROI_092_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_092_Red
@@ -2760,6 +2943,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_092_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_092_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_092_Red/imaging_plane -> /general/optophysiology/Zstack0132_red
+/acquisition/ROI_092_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x110103a9"
 /acquisition/ROI_092_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_093_Green
@@ -2775,6 +2959,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_093_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_093_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_093_Green/imaging_plane -> /general/optophysiology/Zstack0131_green
+/acquisition/ROI_093_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x1593044e"
 /acquisition/ROI_093_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_093_Red
@@ -2790,6 +2975,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_093_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_093_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_093_Red/imaging_plane -> /general/optophysiology/Zstack0131_red
+/acquisition/ROI_093_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x1593044e"
 /acquisition/ROI_093_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_094_Green
@@ -2805,6 +2991,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_094_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_094_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_094_Green/imaging_plane -> /general/optophysiology/Zstack0131_green
+/acquisition/ROI_094_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x122c03f4"
 /acquisition/ROI_094_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_094_Red
@@ -2820,6 +3007,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_094_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_094_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_094_Red/imaging_plane -> /general/optophysiology/Zstack0131_red
+/acquisition/ROI_094_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x122c03f4"
 /acquisition/ROI_094_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_095_Green
@@ -2835,6 +3023,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_095_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_095_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_095_Green/imaging_plane -> /general/optophysiology/Zstack0131_green
+/acquisition/ROI_095_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x13c8039b"
 /acquisition/ROI_095_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_095_Red
@@ -2850,6 +3039,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_095_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_095_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_095_Red/imaging_plane -> /general/optophysiology/Zstack0131_red
+/acquisition/ROI_095_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x13c8039b"
 /acquisition/ROI_095_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_096_Green
@@ -2865,6 +3055,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_096_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_096_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_096_Green/imaging_plane -> /general/optophysiology/Zstack0131_green
+/acquisition/ROI_096_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x155d0440"
 /acquisition/ROI_096_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_096_Red
@@ -2880,6 +3071,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_096_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_096_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_096_Red/imaging_plane -> /general/optophysiology/Zstack0131_red
+/acquisition/ROI_096_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x155d0440"
 /acquisition/ROI_096_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_097_Green
@@ -2895,6 +3087,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_097_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_097_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_097_Green/imaging_plane -> /general/optophysiology/Zstack0131_green
+/acquisition/ROI_097_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x11f603e6"
 /acquisition/ROI_097_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_097_Red
@@ -2910,6 +3103,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_097_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_097_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_097_Red/imaging_plane -> /general/optophysiology/Zstack0131_red
+/acquisition/ROI_097_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x11f603e6"
 /acquisition/ROI_097_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_098_Green
@@ -2925,6 +3119,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_098_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_098_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_098_Green/imaging_plane -> /general/optophysiology/Zstack0131_green
+/acquisition/ROI_098_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xf8e038c"
 /acquisition/ROI_098_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_098_Red
@@ -2940,6 +3135,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_098_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_098_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_098_Red/imaging_plane -> /general/optophysiology/Zstack0131_red
+/acquisition/ROI_098_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xf8e038c"
 /acquisition/ROI_098_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_099_Green
@@ -2955,6 +3151,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_099_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_099_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_099_Green/imaging_plane -> /general/optophysiology/Zstack0131_green
+/acquisition/ROI_099_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xf2c0333"
 /acquisition/ROI_099_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_099_Red
@@ -2970,6 +3167,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_099_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_099_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_099_Red/imaging_plane -> /general/optophysiology/Zstack0131_red
+/acquisition/ROI_099_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xf2c0333"
 /acquisition/ROI_099_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_100_Green
@@ -2985,6 +3183,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_100_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_100_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_100_Green/imaging_plane -> /general/optophysiology/Zstack0130_green
+/acquisition/ROI_100_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x11c003d8"
 /acquisition/ROI_100_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_100_Red
@@ -3000,6 +3199,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_100_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_100_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_100_Red/imaging_plane -> /general/optophysiology/Zstack0130_red
+/acquisition/ROI_100_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x11c003d8"
 /acquisition/ROI_100_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_101_Green
@@ -3015,6 +3215,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_101_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_101_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_101_Green/imaging_plane -> /general/optophysiology/Zstack0130_green
+/acquisition/ROI_101_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xf58037e"
 /acquisition/ROI_101_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_101_Red
@@ -3030,6 +3231,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_101_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_101_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_101_Red/imaging_plane -> /general/optophysiology/Zstack0130_red
+/acquisition/ROI_101_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xf58037e"
 /acquisition/ROI_101_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_102_Green
@@ -3045,6 +3247,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_102_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_102_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_102_Green/imaging_plane -> /general/optophysiology/Zstack0130_green
+/acquisition/ROI_102_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x13f20424"
 /acquisition/ROI_102_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_102_Red
@@ -3060,6 +3263,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_102_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_102_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_102_Red/imaging_plane -> /general/optophysiology/Zstack0130_red
+/acquisition/ROI_102_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x13f20424"
 /acquisition/ROI_102_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_103_Green
@@ -3075,6 +3279,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_103_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_103_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_103_Green/imaging_plane -> /general/optophysiology/Zstack0130_green
+/acquisition/ROI_103_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xe8c02cb"
 /acquisition/ROI_103_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_103_Red
@@ -3090,6 +3295,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_103_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_103_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_103_Red/imaging_plane -> /general/optophysiology/Zstack0130_red
+/acquisition/ROI_103_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xe8c02cb"
 /acquisition/ROI_103_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_104_Green
@@ -3105,6 +3311,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_104_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_104_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_104_Green/imaging_plane -> /general/optophysiology/Zstack0130_green
+/acquisition/ROI_104_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x171b046f"
 /acquisition/ROI_104_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_104_Red
@@ -3120,6 +3327,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_104_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_104_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_104_Red/imaging_plane -> /general/optophysiology/Zstack0130_red
+/acquisition/ROI_104_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x171b046f"
 /acquisition/ROI_104_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_105_Green
@@ -3135,6 +3343,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_105_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_105_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_105_Green/imaging_plane -> /general/optophysiology/Zstack0129_green
+/acquisition/ROI_105_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x13b40415"
 /acquisition/ROI_105_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_105_Red
@@ -3150,6 +3359,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_105_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_105_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_105_Red/imaging_plane -> /general/optophysiology/Zstack0129_red
+/acquisition/ROI_105_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x13b40415"
 /acquisition/ROI_105_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_106_Green
@@ -3165,6 +3375,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_106_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_106_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_106_Green/imaging_plane -> /general/optophysiology/Zstack0129_green
+/acquisition/ROI_106_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x105503bc"
 /acquisition/ROI_106_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_106_Red
@@ -3180,6 +3391,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_106_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_106_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_106_Red/imaging_plane -> /general/optophysiology/Zstack0129_red
+/acquisition/ROI_106_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x105503bc"
 /acquisition/ROI_106_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_107_Green
@@ -3195,6 +3407,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_107_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_107_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_107_Green/imaging_plane -> /general/optophysiology/Zstack0129_green
+/acquisition/ROI_107_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xaef0263"
 /acquisition/ROI_107_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_107_Red
@@ -3210,6 +3423,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_107_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_107_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_107_Red/imaging_plane -> /general/optophysiology/Zstack0129_red
+/acquisition/ROI_107_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xaef0263"
 /acquisition/ROI_107_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_108_Green
@@ -3225,6 +3439,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_108_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_108_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_108_Green/imaging_plane -> /general/optophysiology/Zstack0129_green
+/acquisition/ROI_108_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xf810308"
 /acquisition/ROI_108_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_108_Red
@@ -3240,6 +3455,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_108_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_108_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_108_Red/imaging_plane -> /general/optophysiology/Zstack0129_red
+/acquisition/ROI_108_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xf810308"
 /acquisition/ROI_108_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_109_Green
@@ -3255,6 +3471,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_109_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_109_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_109_Green/imaging_plane -> /general/optophysiology/Zstack0129_green
+/acquisition/ROI_109_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x111603ad"
 /acquisition/ROI_109_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_109_Red
@@ -3270,6 +3487,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_109_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_109_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_109_Red/imaging_plane -> /general/optophysiology/Zstack0129_red
+/acquisition/ROI_109_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x111603ad"
 /acquisition/ROI_109_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_110_Green
@@ -3285,6 +3503,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_110_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_110_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_110_Green/imaging_plane -> /general/optophysiology/Zstack0129_green
+/acquisition/ROI_110_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x15b00453"
 /acquisition/ROI_110_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_110_Red
@@ -3300,6 +3519,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_110_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_110_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_110_Red/imaging_plane -> /general/optophysiology/Zstack0129_red
+/acquisition/ROI_110_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x15b00453"
 /acquisition/ROI_110_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_111_Green
@@ -3315,6 +3535,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_111_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_111_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_111_Green/imaging_plane -> /general/optophysiology/Zstack0134_green
+/acquisition/ROI_111_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x124903f9"
 /acquisition/ROI_111_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_111_Red
@@ -3330,6 +3551,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_111_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_111_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_111_Red/imaging_plane -> /general/optophysiology/Zstack0134_red
+/acquisition/ROI_111_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x124903f9"
 /acquisition/ROI_111_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_112_Green
@@ -3345,6 +3567,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_112_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_112_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_112_Green/imaging_plane -> /general/optophysiology/Zstack0134_green
+/acquisition/ROI_112_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x13dd039f"
 /acquisition/ROI_112_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_112_Red
@@ -3360,6 +3583,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_112_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_112_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_112_Red/imaging_plane -> /general/optophysiology/Zstack0134_red
+/acquisition/ROI_112_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x13dd039f"
 /acquisition/ROI_112_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_113_Green
@@ -3375,6 +3599,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_113_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_113_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_113_Green/imaging_plane -> /general/optophysiology/Zstack0134_green
+/acquisition/ROI_113_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x157a0445"
 /acquisition/ROI_113_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_113_Red
@@ -3390,6 +3615,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_113_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_113_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_113_Red/imaging_plane -> /general/optophysiology/Zstack0134_red
+/acquisition/ROI_113_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x157a0445"
 /acquisition/ROI_113_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_114_Green
@@ -3405,6 +3631,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_114_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_114_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_114_Green/imaging_plane -> /general/optophysiology/Zstack0134_green
+/acquisition/ROI_114_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xb1902ec"
 /acquisition/ROI_114_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_114_Red
@@ -3420,6 +3647,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_114_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_114_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_114_Red/imaging_plane -> /general/optophysiology/Zstack0134_red
+/acquisition/ROI_114_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xb1902ec"
 /acquisition/ROI_114_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_115_Green
@@ -3435,6 +3663,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_115_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_115_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_115_Green/imaging_plane -> /general/optophysiology/Zstack0134_green
+/acquisition/ROI_115_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xfab0391"
 /acquisition/ROI_115_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_115_Red
@@ -3450,6 +3679,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_115_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_115_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_115_Red/imaging_plane -> /general/optophysiology/Zstack0134_red
+/acquisition/ROI_115_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xfab0391"
 /acquisition/ROI_115_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_116_Green
@@ -3465,6 +3695,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_116_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_116_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_116_Green/imaging_plane -> /general/optophysiology/Zstack0134_green
+/acquisition/ROI_116_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x83801f4"
 /acquisition/ROI_116_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_116_Red
@@ -3480,6 +3711,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_116_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_116_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_116_Red/imaging_plane -> /general/optophysiology/Zstack0134_red
+/acquisition/ROI_116_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x83801f4"
 /acquisition/ROI_116_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_117_Green
@@ -3495,6 +3727,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_117_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_117_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_117_Green/imaging_plane -> /general/optophysiology/Zstack0134_green
+/acquisition/ROI_117_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x10fc03c5"
 /acquisition/ROI_117_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_117_Red
@@ -3510,6 +3743,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_117_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_117_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_117_Red/imaging_plane -> /general/optophysiology/Zstack0134_red
+/acquisition/ROI_117_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x10fc03c5"
 /acquisition/ROI_117_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_118_Green
@@ -3525,6 +3759,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_118_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_118_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_118_Green/imaging_plane -> /general/optophysiology/Zstack0134_green
+/acquisition/ROI_118_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x10c70398"
 /acquisition/ROI_118_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_118_Red
@@ -3540,6 +3775,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_118_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_118_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_118_Red/imaging_plane -> /general/optophysiology/Zstack0134_red
+/acquisition/ROI_118_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x10c70398"
 /acquisition/ROI_118_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_119_Green
@@ -3555,6 +3791,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_119_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_119_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_119_Green/imaging_plane -> /general/optophysiology/Zstack0134_green
+/acquisition/ROI_119_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x158e046a"
 /acquisition/ROI_119_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_119_Red
@@ -3570,6 +3807,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_119_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_119_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_119_Red/imaging_plane -> /general/optophysiology/Zstack0134_red
+/acquisition/ROI_119_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x158e046a"
 /acquisition/ROI_119_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_120_Green
@@ -3585,6 +3823,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_120_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_120_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_120_Green/imaging_plane -> /general/optophysiology/Zstack0133_green
+/acquisition/ROI_120_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xe5f033e"
 /acquisition/ROI_120_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_120_Red
@@ -3600,6 +3839,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_120_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_120_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_120_Red/imaging_plane -> /general/optophysiology/Zstack0133_red
+/acquisition/ROI_120_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xe5f033e"
 /acquisition/ROI_120_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_121_Green
@@ -3615,6 +3855,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_121_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_121_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_121_Green/imaging_plane -> /general/optophysiology/Zstack0133_green
+/acquisition/ROI_121_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xd2e0341"
 /acquisition/ROI_121_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_121_Red
@@ -3630,6 +3871,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_121_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_121_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_121_Red/imaging_plane -> /general/optophysiology/Zstack0133_red
+/acquisition/ROI_121_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xd2e0341"
 /acquisition/ROI_121_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_122_Green
@@ -3645,6 +3887,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_122_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_122_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_122_Green/imaging_plane -> /general/optophysiology/Zstack0133_green
+/acquisition/ROI_122_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xeff0315"
 /acquisition/ROI_122_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_122_Red
@@ -3660,6 +3903,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_122_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_122_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_122_Red/imaging_plane -> /general/optophysiology/Zstack0133_red
+/acquisition/ROI_122_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xeff0315"
 /acquisition/ROI_122_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_123_Green
@@ -3675,6 +3919,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_123_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_123_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_123_Green/imaging_plane -> /general/optophysiology/Zstack0133_green
+/acquisition/ROI_123_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x13c603e7"
 /acquisition/ROI_123_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_123_Red
@@ -3690,6 +3935,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_123_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_123_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_123_Red/imaging_plane -> /general/optophysiology/Zstack0133_red
+/acquisition/ROI_123_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x13c603e7"
 /acquisition/ROI_123_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_124_Green
@@ -3705,6 +3951,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_124_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_124_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_124_Green/imaging_plane -> /general/optophysiology/Zstack0133_green
+/acquisition/ROI_124_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xc9702bb"
 /acquisition/ROI_124_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_124_Red
@@ -3720,6 +3967,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_124_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_124_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_124_Red/imaging_plane -> /general/optophysiology/Zstack0133_red
+/acquisition/ROI_124_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xc9702bb"
 /acquisition/ROI_124_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_125_Green
@@ -3735,6 +3983,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_125_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_125_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_125_Green/imaging_plane -> /general/optophysiology/Zstack0133_green
+/acquisition/ROI_125_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x115e038d"
 /acquisition/ROI_125_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_125_Red
@@ -3750,6 +3999,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_125_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_125_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_125_Red/imaging_plane -> /general/optophysiology/Zstack0133_red
+/acquisition/ROI_125_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x115e038d"
 /acquisition/ROI_125_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_126_Green
@@ -3765,6 +4015,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_126_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_126_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_126_Green/imaging_plane -> /general/optophysiology/Zstack0133_green
+/acquisition/ROI_126_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x11290360"
 /acquisition/ROI_126_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_126_Red
@@ -3780,6 +4031,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_126_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_126_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_126_Red/imaging_plane -> /general/optophysiology/Zstack0133_red
+/acquisition/ROI_126_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x11290360"
 /acquisition/ROI_126_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_127_Green
@@ -3795,6 +4047,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_127_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_127_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_127_Green/imaging_plane -> /general/optophysiology/Zstack0133_green
+/acquisition/ROI_127_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x15f00432"
 /acquisition/ROI_127_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_127_Red
@@ -3810,6 +4063,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_127_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_127_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_127_Red/imaging_plane -> /general/optophysiology/Zstack0133_red
+/acquisition/ROI_127_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x15f00432"
 /acquisition/ROI_127_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_128_Green
@@ -3825,6 +4079,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_128_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_128_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_128_Green/imaging_plane -> /general/optophysiology/Zstack0132_green
+/acquisition/ROI_128_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x13bd0405"
 /acquisition/ROI_128_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_128_Red
@@ -3840,6 +4095,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_128_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_128_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_128_Red/imaging_plane -> /general/optophysiology/Zstack0132_red
+/acquisition/ROI_128_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x13bd0405"
 /acquisition/ROI_128_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_129_Green
@@ -3855,6 +4111,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_129_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_129_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_129_Green/imaging_plane -> /general/optophysiology/Zstack0132_green
+/acquisition/ROI_129_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x178d04d8"
 /acquisition/ROI_129_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_129_Red
@@ -3870,6 +4127,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_129_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_129_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_129_Red/imaging_plane -> /general/optophysiology/Zstack0132_red
+/acquisition/ROI_129_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x178d04d8"
 /acquisition/ROI_129_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_130_Green
@@ -3885,6 +4143,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_130_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_130_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_130_Green/imaging_plane -> /general/optophysiology/Zstack0132_green
+/acquisition/ROI_130_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x145b04ab"
 /acquisition/ROI_130_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_130_Red
@@ -3900,6 +4159,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_130_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_130_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_130_Red/imaging_plane -> /general/optophysiology/Zstack0132_red
+/acquisition/ROI_130_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x145b04ab"
 /acquisition/ROI_130_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_131_Green
@@ -3915,6 +4175,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_131_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_131_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_131_Green/imaging_plane -> /general/optophysiology/Zstack0132_green
+/acquisition/ROI_131_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x1128037f"
 /acquisition/ROI_131_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_131_Red
@@ -3930,6 +4191,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_131_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_131_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_131_Red/imaging_plane -> /general/optophysiology/Zstack0132_red
+/acquisition/ROI_131_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x1128037f"
 /acquisition/ROI_131_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_132_Green
@@ -3945,6 +4207,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_132_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_132_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_132_Green/imaging_plane -> /general/optophysiology/Zstack0132_green
+/acquisition/ROI_132_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xef50352"
 /acquisition/ROI_132_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_132_Red
@@ -3960,6 +4223,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_132_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_132_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_132_Red/imaging_plane -> /general/optophysiology/Zstack0132_red
+/acquisition/ROI_132_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xef50352"
 /acquisition/ROI_132_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_133_Green
@@ -3975,6 +4239,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_133_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_133_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_133_Green/imaging_plane -> /general/optophysiology/Zstack0135_green
+/acquisition/ROI_133_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xdc10325"
 /acquisition/ROI_133_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_133_Red
@@ -3990,6 +4255,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_133_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_133_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_133_Red/imaging_plane -> /general/optophysiology/Zstack0135_red
+/acquisition/ROI_133_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xdc10325"
 /acquisition/ROI_133_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_134_Green
@@ -4005,6 +4271,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_134_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_134_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_134_Green/imaging_plane -> /general/optophysiology/Zstack0135_green
+/acquisition/ROI_134_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xd8c02f8"
 /acquisition/ROI_134_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_134_Red
@@ -4020,6 +4287,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_134_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_134_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_134_Red/imaging_plane -> /general/optophysiology/Zstack0135_red
+/acquisition/ROI_134_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xd8c02f8"
 /acquisition/ROI_134_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_135_Green
@@ -4035,6 +4303,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_135_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_135_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_135_Green/imaging_plane -> /general/optophysiology/Zstack0135_green
+/acquisition/ROI_135_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x125303ca"
 /acquisition/ROI_135_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_135_Red
@@ -4050,6 +4319,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_135_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_135_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_135_Red/imaging_plane -> /general/optophysiology/Zstack0135_red
+/acquisition/ROI_135_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x125303ca"
 /acquisition/ROI_135_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_136_Green
@@ -4065,6 +4335,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_136_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_136_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_136_Green/imaging_plane -> /general/optophysiology/Zstack0135_green
+/acquisition/ROI_136_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xb24029e"
 /acquisition/ROI_136_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_136_Red
@@ -4080,6 +4351,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_136_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_136_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_136_Red/imaging_plane -> /general/optophysiology/Zstack0135_red
+/acquisition/ROI_136_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xb24029e"
 /acquisition/ROI_136_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_137_Green
@@ -4095,6 +4367,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_137_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_137_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_137_Green/imaging_plane -> /general/optophysiology/Zstack0135_green
+/acquisition/ROI_137_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xff30371"
 /acquisition/ROI_137_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_137_Red
@@ -4110,6 +4383,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_137_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_137_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_137_Red/imaging_plane -> /general/optophysiology/Zstack0135_red
+/acquisition/ROI_137_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xff30371"
 /acquisition/ROI_137_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_138_Green
@@ -4125,6 +4399,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_138_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_138_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_138_Green/imaging_plane -> /general/optophysiology/Zstack0135_green
+/acquisition/ROI_138_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x13bb0443"
 /acquisition/ROI_138_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_138_Red
@@ -4140,6 +4415,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_138_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_138_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_138_Red/imaging_plane -> /general/optophysiology/Zstack0135_red
+/acquisition/ROI_138_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x13bb0443"
 /acquisition/ROI_138_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_139_Green
@@ -4155,6 +4431,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_139_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_139_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_139_Green/imaging_plane -> /general/optophysiology/Zstack0136_green
+/acquisition/ROI_139_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x15840416"
 /acquisition/ROI_139_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_139_Red
@@ -4170,6 +4447,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_139_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_139_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_139_Red/imaging_plane -> /general/optophysiology/Zstack0136_red
+/acquisition/ROI_139_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x15840416"
 /acquisition/ROI_139_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_140_Green
@@ -4185,6 +4463,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_140_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_140_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_140_Green/imaging_plane -> /general/optophysiology/Zstack0136_green
+/acquisition/ROI_140_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x135103e9"
 /acquisition/ROI_140_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_140_Red
@@ -4200,6 +4479,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_140_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_140_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_140_Red/imaging_plane -> /general/optophysiology/Zstack0136_red
+/acquisition/ROI_140_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x135103e9"
 /acquisition/ROI_140_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_141_Green
@@ -4215,6 +4495,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_141_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_141_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_141_Green/imaging_plane -> /general/optophysiology/Zstack0136_green
+/acquisition/ROI_141_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x131c03bc"
 /acquisition/ROI_141_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_141_Red
@@ -4230,6 +4511,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_141_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_141_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_141_Red/imaging_plane -> /general/optophysiology/Zstack0136_red
+/acquisition/ROI_141_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x131c03bc"
 /acquisition/ROI_141_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_142_Green
@@ -4245,6 +4527,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_142_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_142_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_142_Green/imaging_plane -> /general/optophysiology/Zstack0136_green
+/acquisition/ROI_142_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x17e3048e"
 /acquisition/ROI_142_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_142_Red
@@ -4260,6 +4543,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_142_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_142_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_142_Red/imaging_plane -> /general/optophysiology/Zstack0136_red
+/acquisition/ROI_142_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x17e3048e"
 /acquisition/ROI_142_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_143_Green
@@ -4275,6 +4559,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_143_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_143_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_143_Green/imaging_plane -> /general/optophysiology/Zstack0136_green
+/acquisition/ROI_143_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x10b40362"
 /acquisition/ROI_143_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_143_Red
@@ -4290,6 +4575,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_143_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_143_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_143_Red/imaging_plane -> /general/optophysiology/Zstack0136_red
+/acquisition/ROI_143_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x10b40362"
 /acquisition/ROI_143_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_144_Green
@@ -4305,6 +4591,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_144_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_144_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_144_Green/imaging_plane -> /general/optophysiology/Zstack0137_green
+/acquisition/ROI_144_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xf880336"
 /acquisition/ROI_144_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_144_Red
@@ -4320,6 +4607,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_144_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_144_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_144_Red/imaging_plane -> /general/optophysiology/Zstack0137_red
+/acquisition/ROI_144_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xf880336"
 /acquisition/ROI_144_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_145_Green
@@ -4335,6 +4623,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_145_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_145_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_145_Green/imaging_plane -> /general/optophysiology/Zstack0137_green
+/acquisition/ROI_145_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x144f0408"
 /acquisition/ROI_145_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_145_Red
@@ -4350,6 +4639,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_145_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_145_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_145_Red/imaging_plane -> /general/optophysiology/Zstack0137_red
+/acquisition/ROI_145_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x144f0408"
 /acquisition/ROI_145_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_146_Green
@@ -4365,6 +4655,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_146_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_146_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_146_Green/imaging_plane -> /general/optophysiology/Zstack0137_green
+/acquisition/ROI_146_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x141a03db"
 /acquisition/ROI_146_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_146_Red
@@ -4380,6 +4671,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_146_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_146_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_146_Red/imaging_plane -> /general/optophysiology/Zstack0137_red
+/acquisition/ROI_146_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x141a03db"
 /acquisition/ROI_146_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_147_Green
@@ -4395,6 +4687,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_147_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_147_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_147_Green/imaging_plane -> /general/optophysiology/Zstack0137_green
+/acquisition/ROI_147_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xdeb03ae"
 /acquisition/ROI_147_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_147_Red
@@ -4410,6 +4703,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_147_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_147_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_147_Red/imaging_plane -> /general/optophysiology/Zstack0137_red
+/acquisition/ROI_147_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xdeb03ae"
 /acquisition/ROI_147_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_148_Green
@@ -4425,6 +4719,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_148_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_148_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_148_Green/imaging_plane -> /general/optophysiology/Zstack0137_green
+/acquisition/ROI_148_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xab80282"
 /acquisition/ROI_148_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_148_Red
@@ -4440,6 +4735,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_148_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_148_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_148_Red/imaging_plane -> /general/optophysiology/Zstack0137_red
+/acquisition/ROI_148_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xab80282"
 /acquisition/ROI_148_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_149_Green
@@ -4455,6 +4751,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_149_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_149_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_149_Green/imaging_plane -> /general/optophysiology/Zstack0138_green
+/acquisition/ROI_149_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xf7f0354"
 /acquisition/ROI_149_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_149_Red
@@ -4470,6 +4767,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_149_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_149_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_149_Red/imaging_plane -> /general/optophysiology/Zstack0138_red
+/acquisition/ROI_149_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xf7f0354"
 /acquisition/ROI_149_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_150_Green
@@ -4485,6 +4783,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_150_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_150_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_150_Green/imaging_plane -> /general/optophysiology/Zstack0138_green
+/acquisition/ROI_150_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x14460426"
 /acquisition/ROI_150_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_150_Red
@@ -4500,6 +4799,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_150_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_150_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_150_Red/imaging_plane -> /general/optophysiology/Zstack0138_red
+/acquisition/ROI_150_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x14460426"
 /acquisition/ROI_150_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_151_Green
@@ -4515,6 +4815,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_151_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_151_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_151_Green/imaging_plane -> /general/optophysiology/Zstack0138_green
+/acquisition/ROI_151_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xd1f02fb"
 /acquisition/ROI_151_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_151_Red
@@ -4530,6 +4831,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_151_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_151_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_151_Red/imaging_plane -> /general/optophysiology/Zstack0138_red
+/acquisition/ROI_151_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xd1f02fb"
 /acquisition/ROI_151_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_152_Green
@@ -4545,6 +4847,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_152_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_152_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_152_Green/imaging_plane -> /general/optophysiology/Zstack0138_green
+/acquisition/ROI_152_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x11e603cd"
 /acquisition/ROI_152_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_152_Red
@@ -4560,6 +4863,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_152_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_152_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_152_Red/imaging_plane -> /general/optophysiology/Zstack0138_red
+/acquisition/ROI_152_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x11e603cd"
 /acquisition/ROI_152_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_153_Green
@@ -4575,6 +4879,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_153_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_153_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_153_Green/imaging_plane -> /general/optophysiology/Zstack0126_green
+/acquisition/ROI_153_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x11b103a0"
 /acquisition/ROI_153_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_153_Red
@@ -4590,6 +4895,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_153_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_153_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_153_Red/imaging_plane -> /general/optophysiology/Zstack0126_red
+/acquisition/ROI_153_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x11b103a0"
 /acquisition/ROI_153_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_154_Green
@@ -4605,6 +4911,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_154_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_154_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_154_Green/imaging_plane -> /general/optophysiology/Zstack0126_green
+/acquisition/ROI_154_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x16780472"
 /acquisition/ROI_154_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_154_Red
@@ -4620,6 +4927,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_154_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_154_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_154_Red/imaging_plane -> /general/optophysiology/Zstack0126_red
+/acquisition/ROI_154_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x16780472"
 /acquisition/ROI_154_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_155_Green
@@ -4635,6 +4943,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_155_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_155_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_155_Green/imaging_plane -> /general/optophysiology/Zstack0126_green
+/acquisition/ROI_155_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x18420544"
 /acquisition/ROI_155_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_155_Red
@@ -4650,6 +4959,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_155_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_155_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_155_Red/imaging_plane -> /general/optophysiology/Zstack0126_red
+/acquisition/ROI_155_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x18420544"
 /acquisition/ROI_155_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_156_Green
@@ -4665,6 +4975,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_156_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_156_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_156_Green/imaging_plane -> /general/optophysiology/Zstack0126_green
+/acquisition/ROI_156_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x12120418"
 /acquisition/ROI_156_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_156_Red
@@ -4680,6 +4991,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_156_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_156_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_156_Red/imaging_plane -> /general/optophysiology/Zstack0126_red
+/acquisition/ROI_156_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x12120418"
 /acquisition/ROI_156_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_157_Green
@@ -4695,6 +5007,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_157_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_157_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_157_Green/imaging_plane -> /general/optophysiology/Zstack0126_green
+/acquisition/ROI_157_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x13db03eb"
 /acquisition/ROI_157_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_157_Red
@@ -4710,6 +5023,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_157_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_157_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_157_Red/imaging_plane -> /general/optophysiology/Zstack0126_red
+/acquisition/ROI_157_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x13db03eb"
 /acquisition/ROI_157_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_158_Green
@@ -4725,6 +5039,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_158_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_158_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_158_Green/imaging_plane -> /general/optophysiology/Zstack0127_green
+/acquisition/ROI_158_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xcb402c0"
 /acquisition/ROI_158_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_158_Red
@@ -4740,6 +5055,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_158_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_158_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_158_Red/imaging_plane -> /general/optophysiology/Zstack0127_red
+/acquisition/ROI_158_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xcb402c0"
 /acquisition/ROI_158_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_159_Green
@@ -4755,6 +5071,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_159_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_159_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_159_Green/imaging_plane -> /general/optophysiology/Zstack0127_green
+/acquisition/ROI_159_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x117b0392"
 /acquisition/ROI_159_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_159_Red
@@ -4770,6 +5087,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_159_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_159_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_159_Red/imaging_plane -> /general/optophysiology/Zstack0127_red
+/acquisition/ROI_159_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x117b0392"
 /acquisition/ROI_159_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_160_Green
@@ -4785,6 +5103,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_160_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_160_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_160_Green/imaging_plane -> /general/optophysiology/Zstack0127_green
+/acquisition/ROI_160_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x11460365"
 /acquisition/ROI_160_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_160_Red
@@ -4800,6 +5119,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_160_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_160_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_160_Red/imaging_plane -> /general/optophysiology/Zstack0127_red
+/acquisition/ROI_160_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x11460365"
 /acquisition/ROI_160_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_161_Green
@@ -4815,6 +5135,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_161_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_161_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_161_Green/imaging_plane -> /general/optophysiology/Zstack0152_green
+/acquisition/ROI_161_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x160d0437"
 /acquisition/ROI_161_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_161_Red
@@ -4830,6 +5151,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_161_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_161_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_161_Red/imaging_plane -> /general/optophysiology/Zstack0152_red
+/acquisition/ROI_161_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x160d0437"
 /acquisition/ROI_161_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_162_Green
@@ -4845,6 +5167,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_162_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_162_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_162_Green/imaging_plane -> /general/optophysiology/Zstack0152_green
+/acquisition/ROI_162_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x13da040a"
 /acquisition/ROI_162_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_162_Red
@@ -4860,6 +5183,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_162_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_162_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_162_Red/imaging_plane -> /general/optophysiology/Zstack0152_red
+/acquisition/ROI_162_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x13da040a"
 /acquisition/ROI_162_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_163_Green
@@ -4875,6 +5199,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_163_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_163_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_163_Green/imaging_plane -> /general/optophysiology/Zstack0152_green
+/acquisition/ROI_163_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x13a503dd"
 /acquisition/ROI_163_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_163_Red
@@ -4890,6 +5215,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_163_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_163_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_163_Red/imaging_plane -> /general/optophysiology/Zstack0152_red
+/acquisition/ROI_163_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x13a503dd"
 /acquisition/ROI_163_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_164_Green
@@ -4905,6 +5231,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_164_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_164_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_164_Green/imaging_plane -> /general/optophysiology/Zstack0152_green
+/acquisition/ROI_164_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x147004af"
 /acquisition/ROI_164_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_164_Red
@@ -4920,6 +5247,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_164_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_164_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_164_Red/imaging_plane -> /general/optophysiology/Zstack0152_red
+/acquisition/ROI_164_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x147004af"
 /acquisition/ROI_164_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_165_Green
@@ -4935,6 +5263,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_165_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_165_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_165_Green/imaging_plane -> /general/optophysiology/Zstack0152_green
+/acquisition/ROI_165_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x11450384"
 /acquisition/ROI_165_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_165_Red
@@ -4950,6 +5279,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_165_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_165_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_165_Red/imaging_plane -> /general/optophysiology/Zstack0152_red
+/acquisition/ROI_165_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x11450384"
 /acquisition/ROI_165_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_166_Green
@@ -4965,6 +5295,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_166_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_166_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_166_Green/imaging_plane -> /general/optophysiology/Zstack0152_green
+/acquisition/ROI_166_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xf120357"
 /acquisition/ROI_166_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_166_Red
@@ -4980,6 +5311,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_166_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_166_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_166_Red/imaging_plane -> /general/optophysiology/Zstack0152_red
+/acquisition/ROI_166_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xf120357"
 /acquisition/ROI_166_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_167_Green
@@ -4995,6 +5327,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_167_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_167_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_167_Green/imaging_plane -> /general/optophysiology/Zstack0152_green
+/acquisition/ROI_167_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xdde032a"
 /acquisition/ROI_167_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_167_Red
@@ -5010,6 +5343,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_167_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_167_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_167_Red/imaging_plane -> /general/optophysiology/Zstack0152_red
+/acquisition/ROI_167_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xdde032a"
 /acquisition/ROI_167_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_168_Green
@@ -5025,6 +5359,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_168_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_168_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_168_Green/imaging_plane -> /general/optophysiology/Zstack0153_green
+/acquisition/ROI_168_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xda902fd"
 /acquisition/ROI_168_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_168_Red
@@ -5040,6 +5375,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_168_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_168_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_168_Red/imaging_plane -> /general/optophysiology/Zstack0153_red
+/acquisition/ROI_168_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xda902fd"
 /acquisition/ROI_168_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_169_Green
@@ -5055,6 +5391,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_169_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_169_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_169_Green/imaging_plane -> /general/optophysiology/Zstack0153_green
+/acquisition/ROI_169_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x127003cf"
 /acquisition/ROI_169_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_169_Red
@@ -5070,6 +5407,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_169_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_169_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_169_Red/imaging_plane -> /general/optophysiology/Zstack0153_red
+/acquisition/ROI_169_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x127003cf"
 /acquisition/ROI_169_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_170_Green
@@ -5085,6 +5423,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_170_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_170_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_170_Green/imaging_plane -> /general/optophysiology/Zstack0153_green
+/acquisition/ROI_170_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xb4102a3"
 /acquisition/ROI_170_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_170_Red
@@ -5100,6 +5439,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_170_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_170_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_170_Red/imaging_plane -> /general/optophysiology/Zstack0153_red
+/acquisition/ROI_170_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xb4102a3"
 /acquisition/ROI_170_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_171_Green
@@ -5115,6 +5455,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_171_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_171_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_171_Green/imaging_plane -> /general/optophysiology/Zstack0153_green
+/acquisition/ROI_171_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x10080375"
 /acquisition/ROI_171_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_171_Red
@@ -5130,6 +5471,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_171_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_171_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_171_Red/imaging_plane -> /general/optophysiology/Zstack0153_red
+/acquisition/ROI_171_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x10080375"
 /acquisition/ROI_171_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_172_Green
@@ -5145,6 +5487,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_172_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_172_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_172_Green/imaging_plane -> /general/optophysiology/Zstack0151_green
+/acquisition/ROI_172_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x14cf0447"
 /acquisition/ROI_172_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_172_Red
@@ -5160,6 +5503,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_172_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_172_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_172_Red/imaging_plane -> /general/optophysiology/Zstack0151_red
+/acquisition/ROI_172_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x14cf0447"
 /acquisition/ROI_172_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_173_Green
@@ -5175,6 +5519,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_173_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_173_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_173_Green/imaging_plane -> /general/optophysiology/Zstack0151_green
+/acquisition/ROI_173_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x11a5041b"
 /acquisition/ROI_173_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_173_Red
@@ -5190,6 +5535,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_173_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_173_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_173_Red/imaging_plane -> /general/optophysiology/Zstack0151_red
+/acquisition/ROI_173_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x11a5041b"
 /acquisition/ROI_173_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_174_Green
@@ -5205,6 +5551,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_174_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_174_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_174_Green/imaging_plane -> /general/optophysiology/Zstack0151_green
+/acquisition/ROI_174_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x136e03ee"
 /acquisition/ROI_174_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_174_Red
@@ -5220,6 +5567,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_174_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_174_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_174_Red/imaging_plane -> /general/optophysiology/Zstack0151_red
+/acquisition/ROI_174_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x136e03ee"
 /acquisition/ROI_174_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_175_Green
@@ -5235,6 +5583,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_175_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_175_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_175_Green/imaging_plane -> /general/optophysiology/Zstack0148_green
+/acquisition/ROI_175_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x133903c1"
 /acquisition/ROI_175_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_175_Red
@@ -5250,6 +5599,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_175_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_175_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_175_Red/imaging_plane -> /general/optophysiology/Zstack0148_red
+/acquisition/ROI_175_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x133903c1"
 /acquisition/ROI_175_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_176_Green
@@ -5265,6 +5615,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_176_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_176_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_176_Green/imaging_plane -> /general/optophysiology/Zstack0148_green
+/acquisition/ROI_176_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x18000493"
 /acquisition/ROI_176_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_176_Red
@@ -5280,6 +5631,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_176_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_176_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_176_Red/imaging_plane -> /general/optophysiology/Zstack0148_red
+/acquisition/ROI_176_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x18000493"
 /acquisition/ROI_176_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_177_Green
@@ -5295,6 +5647,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_177_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_177_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_177_Green/imaging_plane -> /general/optophysiology/Zstack0148_green
+/acquisition/ROI_177_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x10d10367"
 /acquisition/ROI_177_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_177_Red
@@ -5310,6 +5663,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_177_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_177_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_177_Red/imaging_plane -> /general/optophysiology/Zstack0148_red
+/acquisition/ROI_177_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x10d10367"
 /acquisition/ROI_177_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_178_Green
@@ -5325,6 +5679,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_178_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_178_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_178_Green/imaging_plane -> /general/optophysiology/Zstack0148_green
+/acquisition/ROI_178_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x15980439"
 /acquisition/ROI_178_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_178_Red
@@ -5340,6 +5695,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_178_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_178_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_178_Red/imaging_plane -> /general/optophysiology/Zstack0148_red
+/acquisition/ROI_178_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x15980439"
 /acquisition/ROI_178_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_179_Green
@@ -5355,6 +5711,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_179_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_179_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_179_Green/imaging_plane -> /general/optophysiology/Zstack0149_green
+/acquisition/ROI_179_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x1464040c"
 /acquisition/ROI_179_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_179_Red
@@ -5370,6 +5727,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_179_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_179_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_179_Red/imaging_plane -> /general/optophysiology/Zstack0149_red
+/acquisition/ROI_179_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x1464040c"
 /acquisition/ROI_179_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_180_Green
@@ -5385,6 +5743,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_180_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_180_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_180_Green/imaging_plane -> /general/optophysiology/Zstack0149_green
+/acquisition/ROI_180_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x143703e0"
 /acquisition/ROI_180_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_180_Red
@@ -5400,6 +5759,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_180_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_180_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_180_Red/imaging_plane -> /general/optophysiology/Zstack0149_red
+/acquisition/ROI_180_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x143703e0"
 /acquisition/ROI_180_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_181_Green
@@ -5415,6 +5775,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_181_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_181_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_181_Green/imaging_plane -> /general/optophysiology/Zstack0154_green
+/acquisition/ROI_181_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x71001e5"
 /acquisition/ROI_181_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_181_Red
@@ -5430,6 +5791,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_181_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_181_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_181_Red/imaging_plane -> /general/optophysiology/Zstack0154_red
+/acquisition/ROI_181_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x71001e5"
 /acquisition/ROI_181_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_182_Green
@@ -5445,6 +5807,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_182_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_182_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_182_Green/imaging_plane -> /general/optophysiology/Zstack0154_green
+/acquisition/ROI_182_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xbd702b7"
 /acquisition/ROI_182_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_182_Red
@@ -5460,6 +5823,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_182_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_182_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_182_Red/imaging_plane -> /general/optophysiology/Zstack0154_red
+/acquisition/ROI_182_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xbd702b7"
 /acquisition/ROI_182_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_183_Green
@@ -5475,6 +5839,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_183_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_183_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_183_Green/imaging_plane -> /general/optophysiology/Zstack0154_green
+/acquisition/ROI_183_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x10a6038a"
 /acquisition/ROI_183_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_183_Red
@@ -5490,6 +5855,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_183_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_183_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_183_Red/imaging_plane -> /general/optophysiology/Zstack0154_red
+/acquisition/ROI_183_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x10a6038a"
 /acquisition/ROI_183_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_184_Green
@@ -5505,6 +5871,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_184_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_184_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_184_Green/imaging_plane -> /general/optophysiology/Zstack0154_green
+/acquisition/ROI_184_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x146e045c"
 /acquisition/ROI_184_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_184_Red
@@ -5520,6 +5887,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_184_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_184_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_184_Red/imaging_plane -> /general/optophysiology/Zstack0154_red
+/acquisition/ROI_184_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x146e045c"
 /acquisition/ROI_184_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_185_Green
@@ -5535,6 +5903,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_185_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_185_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_185_Green/imaging_plane -> /general/optophysiology/Zstack0154_green
+/acquisition/ROI_185_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x123b042f"
 /acquisition/ROI_185_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_185_Red
@@ -5550,6 +5919,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_185_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_185_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_185_Red/imaging_plane -> /general/optophysiology/Zstack0154_red
+/acquisition/ROI_185_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x123b042f"
 /acquisition/ROI_185_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_186_Green
@@ -5565,6 +5935,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_186_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_186_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_186_Green/imaging_plane -> /general/optophysiology/Zstack0154_green
+/acquisition/ROI_186_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x12060402"
 /acquisition/ROI_186_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_186_Red
@@ -5580,6 +5951,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_186_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_186_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_186_Red/imaging_plane -> /general/optophysiology/Zstack0154_red
+/acquisition/ROI_186_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x12060402"
 /acquisition/ROI_186_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_187_Green
@@ -5595,6 +5967,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_187_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_187_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_187_Green/imaging_plane -> /general/optophysiology/Zstack0153_green
+/acquisition/ROI_187_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x16cd04d4"
 /acquisition/ROI_187_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_187_Red
@@ -5610,6 +5983,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_187_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_187_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_187_Red/imaging_plane -> /general/optophysiology/Zstack0153_red
+/acquisition/ROI_187_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x16cd04d4"
 /acquisition/ROI_187_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_188_Green
@@ -5625,6 +5999,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_188_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_188_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_188_Green/imaging_plane -> /general/optophysiology/Zstack0153_green
+/acquisition/ROI_188_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x169804a7"
 /acquisition/ROI_188_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_188_Red
@@ -5640,6 +6015,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_188_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_188_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_188_Red/imaging_plane -> /general/optophysiology/Zstack0153_red
+/acquisition/ROI_188_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x169804a7"
 /acquisition/ROI_188_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_189_Green
@@ -5655,6 +6031,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_189_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_189_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_189_Green/imaging_plane -> /general/optophysiology/Zstack0153_green
+/acquisition/ROI_189_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xb6c027c"
 /acquisition/ROI_189_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_189_Red
@@ -5670,6 +6047,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_189_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_189_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_189_Red/imaging_plane -> /general/optophysiology/Zstack0153_red
+/acquisition/ROI_189_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xb6c027c"
 /acquisition/ROI_189_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_190_Green
@@ -5685,6 +6063,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_190_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_190_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_190_Green/imaging_plane -> /general/optophysiology/Zstack0153_green
+/acquisition/ROI_190_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x103b034f"
 /acquisition/ROI_190_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_190_Red
@@ -5700,6 +6079,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_190_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_190_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_190_Red/imaging_plane -> /general/optophysiology/Zstack0153_red
+/acquisition/ROI_190_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x103b034f"
 /acquisition/ROI_190_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_191_Green
@@ -5715,6 +6095,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_191_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_191_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_191_Green/imaging_plane -> /general/optophysiology/Zstack0153_green
+/acquisition/ROI_191_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x10060322"
 /acquisition/ROI_191_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_191_Red
@@ -5730,6 +6111,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_191_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_191_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_191_Red/imaging_plane -> /general/optophysiology/Zstack0153_red
+/acquisition/ROI_191_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x10060322"
 /acquisition/ROI_191_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_192_Green
@@ -5745,6 +6127,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_192_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_192_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_192_Green/imaging_plane -> /general/optophysiology/Zstack0152_green
+/acquisition/ROI_192_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x14cd03f4"
 /acquisition/ROI_192_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_192_Red
@@ -5760,6 +6143,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_192_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_192_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_192_Red/imaging_plane -> /general/optophysiology/Zstack0152_red
+/acquisition/ROI_192_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x14cd03f4"
 /acquisition/ROI_192_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_193_Green
@@ -5775,6 +6159,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_193_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_193_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_193_Green/imaging_plane -> /general/optophysiology/Zstack0152_green
+/acquisition/ROI_193_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x119b03c7"
 /acquisition/ROI_193_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_193_Red
@@ -5790,6 +6175,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_193_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_193_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_193_Red/imaging_plane -> /general/optophysiology/Zstack0152_red
+/acquisition/ROI_193_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x119b03c7"
 /acquisition/ROI_193_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_194_Green
@@ -5805,6 +6191,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_194_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_194_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_194_Green/imaging_plane -> /general/optophysiology/Zstack0152_green
+/acquisition/ROI_194_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x16620499"
 /acquisition/ROI_194_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_194_Red
@@ -5820,6 +6207,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_194_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_194_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_194_Red/imaging_plane -> /general/optophysiology/Zstack0152_red
+/acquisition/ROI_194_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x16620499"
 /acquisition/ROI_194_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_195_Green
@@ -5835,6 +6223,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_195_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_195_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_195_Green/imaging_plane -> /general/optophysiology/Zstack0152_green
+/acquisition/ROI_195_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x1b29056b"
 /acquisition/ROI_195_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_195_Red
@@ -5850,6 +6239,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_195_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_195_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_195_Red/imaging_plane -> /general/optophysiology/Zstack0152_red
+/acquisition/ROI_195_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x1b29056b"
 /acquisition/ROI_195_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_196_Green
@@ -5865,6 +6255,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_196_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_196_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_196_Green/imaging_plane -> /general/optophysiology/Zstack0151_green
+/acquisition/ROI_196_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x1af4053e"
 /acquisition/ROI_196_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_196_Red
@@ -5880,6 +6271,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_196_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_196_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_196_Red/imaging_plane -> /general/optophysiology/Zstack0151_red
+/acquisition/ROI_196_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x1af4053e"
 /acquisition/ROI_196_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_197_Green
@@ -5895,6 +6287,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_197_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_197_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_197_Green/imaging_plane -> /general/optophysiology/Zstack0151_green
+/acquisition/ROI_197_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xdca0313"
 /acquisition/ROI_197_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_197_Red
@@ -5910,6 +6303,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_197_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_197_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_197_Red/imaging_plane -> /general/optophysiology/Zstack0151_red
+/acquisition/ROI_197_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xdca0313"
 /acquisition/ROI_197_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_198_Green
@@ -5925,6 +6319,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_198_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_198_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_198_Green/imaging_plane -> /general/optophysiology/Zstack0151_green
+/acquisition/ROI_198_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xd9d02e7"
 /acquisition/ROI_198_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_198_Red
@@ -5940,6 +6335,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_198_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_198_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_198_Red/imaging_plane -> /general/optophysiology/Zstack0151_red
+/acquisition/ROI_198_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xd9d02e7"
 /acquisition/ROI_198_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_199_Green
@@ -5955,6 +6351,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_199_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_199_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_199_Green/imaging_plane -> /general/optophysiology/Zstack0151_green
+/acquisition/ROI_199_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x126403b9"
 /acquisition/ROI_199_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_199_Red
@@ -5970,6 +6367,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_199_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_199_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_199_Red/imaging_plane -> /general/optophysiology/Zstack0151_red
+/acquisition/ROI_199_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x126403b9"
 /acquisition/ROI_199_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_200_Green
@@ -5985,6 +6383,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_200_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_200_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_200_Green/imaging_plane -> /general/optophysiology/Zstack0150_green
+/acquisition/ROI_200_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xa36028d"
 /acquisition/ROI_200_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_200_Red
@@ -6000,6 +6399,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_200_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_200_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_200_Red/imaging_plane -> /general/optophysiology/Zstack0150_red
+/acquisition/ROI_200_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xa36028d"
 /acquisition/ROI_200_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_201_Green
@@ -6015,6 +6415,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_201_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_201_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_201_Green/imaging_plane -> /general/optophysiology/Zstack0150_green
+/acquisition/ROI_201_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xa010260"
 /acquisition/ROI_201_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_201_Red
@@ -6030,6 +6431,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_201_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_201_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_201_Red/imaging_plane -> /general/optophysiology/Zstack0150_red
+/acquisition/ROI_201_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xa010260"
 /acquisition/ROI_201_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_202_Green
@@ -6045,6 +6447,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_202_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_202_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_202_Green/imaging_plane -> /general/optophysiology/Zstack0149_green
+/acquisition/ROI_202_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x12c50431"
 /acquisition/ROI_202_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_202_Red
@@ -6060,6 +6463,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_202_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_202_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_202_Red/imaging_plane -> /general/optophysiology/Zstack0149_red
+/acquisition/ROI_202_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x12c50431"
 /acquisition/ROI_202_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_203_Green
@@ -6075,6 +6479,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_203_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_203_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_203_Green/imaging_plane -> /general/optophysiology/Zstack0149_green
+/acquisition/ROI_203_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x12900404"
 /acquisition/ROI_203_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_203_Red
@@ -6090,6 +6495,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_203_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_203_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_203_Red/imaging_plane -> /general/optophysiology/Zstack0149_red
+/acquisition/ROI_203_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x12900404"
 /acquisition/ROI_203_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_204_Green
@@ -6105,6 +6511,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_204_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_204_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_204_Green/imaging_plane -> /general/optophysiology/Zstack0149_green
+/acquisition/ROI_204_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x105d03d7"
 /acquisition/ROI_204_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_204_Red
@@ -6120,6 +6527,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_204_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_204_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_204_Red/imaging_plane -> /general/optophysiology/Zstack0149_red
+/acquisition/ROI_204_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x105d03d7"
 /acquisition/ROI_204_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_205_Green
@@ -6135,6 +6543,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_205_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_205_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_205_Green/imaging_plane -> /general/optophysiology/Zstack0149_green
+/acquisition/ROI_205_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x103003ab"
 /acquisition/ROI_205_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_205_Red
@@ -6150,6 +6559,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_205_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_205_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_205_Red/imaging_plane -> /general/optophysiology/Zstack0149_red
+/acquisition/ROI_205_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x103003ab"
 /acquisition/ROI_205_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_206_Green
@@ -6165,6 +6575,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_206_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_206_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_206_Green/imaging_plane -> /general/optophysiology/Zstack0148_green
+/acquisition/ROI_206_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x11f9037e"
 /acquisition/ROI_206_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_206_Red
@@ -6180,6 +6591,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_206_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_206_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_206_Red/imaging_plane -> /general/optophysiology/Zstack0148_red
+/acquisition/ROI_206_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x11f9037e"
 /acquisition/ROI_206_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_207_Green
@@ -6195,6 +6607,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_207_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_207_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_207_Green/imaging_plane -> /general/optophysiology/Zstack0148_green
+/acquisition/ROI_207_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x16c00450"
 /acquisition/ROI_207_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_207_Red
@@ -6210,6 +6623,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_207_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_207_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_207_Red/imaging_plane -> /general/optophysiology/Zstack0148_red
+/acquisition/ROI_207_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x16c00450"
 /acquisition/ROI_207_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_208_Green
@@ -6225,6 +6639,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_208_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_208_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_208_Green/imaging_plane -> /general/optophysiology/Zstack0148_green
+/acquisition/ROI_208_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xf910324"
 /acquisition/ROI_208_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_208_Red
@@ -6240,6 +6655,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_208_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_208_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_208_Red/imaging_plane -> /general/optophysiology/Zstack0148_red
+/acquisition/ROI_208_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xf910324"
 /acquisition/ROI_208_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_209_Green
@@ -6255,6 +6671,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_209_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_209_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_209_Green/imaging_plane -> /general/optophysiology/Zstack0148_green
+/acquisition/ROI_209_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x145803f6"
 /acquisition/ROI_209_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_209_Red
@@ -6270,6 +6687,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_209_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_209_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_209_Red/imaging_plane -> /general/optophysiology/Zstack0148_red
+/acquisition/ROI_209_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x145803f6"
 /acquisition/ROI_209_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_210_Green
@@ -6285,6 +6703,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_210_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_210_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_210_Green/imaging_plane -> /general/optophysiology/Zstack0147_green
+/acquisition/ROI_210_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x182004c8"
 /acquisition/ROI_210_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_210_Red
@@ -6300,6 +6719,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_210_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_210_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_210_Red/imaging_plane -> /general/optophysiology/Zstack0147_red
+/acquisition/ROI_210_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x182004c8"
 /acquisition/ROI_210_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_211_Green
@@ -6315,6 +6735,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_211_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_211_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_211_Green/imaging_plane -> /general/optophysiology/Zstack0147_green
+/acquisition/ROI_211_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x1ce7059a"
 /acquisition/ROI_211_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_211_Red
@@ -6330,6 +6751,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_211_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_211_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_211_Red/imaging_plane -> /general/optophysiology/Zstack0147_red
+/acquisition/ROI_211_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x1ce7059a"
 /acquisition/ROI_211_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_212_Green
@@ -6345,6 +6767,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_212_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_212_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_212_Green/imaging_plane -> /general/optophysiology/Zstack0147_green
+/acquisition/ROI_212_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x14c1046f"
 /acquisition/ROI_212_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_212_Red
@@ -6360,6 +6783,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_212_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_212_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_212_Red/imaging_plane -> /general/optophysiology/Zstack0147_red
+/acquisition/ROI_212_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x14c1046f"
 /acquisition/ROI_212_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_213_Green
@@ -6375,6 +6799,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_213_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_213_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_213_Green/imaging_plane -> /general/optophysiology/Zstack0147_green
+/acquisition/ROI_213_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xc930343"
 /acquisition/ROI_213_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_213_Red
@@ -6390,6 +6815,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_213_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_213_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_213_Red/imaging_plane -> /general/optophysiology/Zstack0147_red
+/acquisition/ROI_213_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xc930343"
 /acquisition/ROI_213_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_214_Green
@@ -6405,6 +6831,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_214_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_214_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_214_Green/imaging_plane -> /general/optophysiology/Zstack0147_green
+/acquisition/ROI_214_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xe5c0316"
 /acquisition/ROI_214_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_214_Red
@@ -6420,6 +6847,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_214_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_214_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_214_Red/imaging_plane -> /general/optophysiology/Zstack0147_red
+/acquisition/ROI_214_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xe5c0316"
 /acquisition/ROI_214_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_215_Green
@@ -6435,6 +6863,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_215_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_215_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_215_Green/imaging_plane -> /general/optophysiology/Zstack0147_green
+/acquisition/ROI_215_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x72d01ea"
 /acquisition/ROI_215_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_215_Red
@@ -6450,6 +6879,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_215_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_215_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_215_Red/imaging_plane -> /general/optophysiology/Zstack0147_red
+/acquisition/ROI_215_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x72d01ea"
 /acquisition/ROI_215_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_216_Green
@@ -6465,6 +6895,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_216_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_216_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_216_Green/imaging_plane -> /general/optophysiology/Zstack0147_green
+/acquisition/ROI_216_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xbf402bc"
 /acquisition/ROI_216_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_216_Red
@@ -6480,6 +6911,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_216_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_216_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_216_Red/imaging_plane -> /general/optophysiology/Zstack0147_red
+/acquisition/ROI_216_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xbf402bc"
 /acquisition/ROI_216_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_217_Green
@@ -6495,6 +6927,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_217_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_217_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_217_Green/imaging_plane -> /general/optophysiology/Zstack0146_green
+/acquisition/ROI_217_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x10bb038e"
 /acquisition/ROI_217_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_217_Red
@@ -6510,6 +6943,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_217_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_217_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_217_Red/imaging_plane -> /general/optophysiology/Zstack0146_red
+/acquisition/ROI_217_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x10bb038e"
 /acquisition/ROI_217_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_218_Green
@@ -6525,6 +6959,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_218_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_218_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_218_Green/imaging_plane -> /general/optophysiology/Zstack0146_green
+/acquisition/ROI_218_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x10860361"
 /acquisition/ROI_218_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_218_Red
@@ -6540,6 +6975,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_218_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_218_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_218_Red/imaging_plane -> /general/optophysiology/Zstack0146_red
+/acquisition/ROI_218_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x10860361"
 /acquisition/ROI_218_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_219_Green
@@ -6555,6 +6991,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_219_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_219_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_219_Green/imaging_plane -> /general/optophysiology/Zstack0146_green
+/acquisition/ROI_219_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x12580434"
 /acquisition/ROI_219_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_219_Red
@@ -6570,6 +7007,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_219_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_219_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_219_Red/imaging_plane -> /general/optophysiology/Zstack0146_red
+/acquisition/ROI_219_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x12580434"
 /acquisition/ROI_219_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_220_Green
@@ -6585,6 +7023,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_220_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_220_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_220_Green/imaging_plane -> /general/optophysiology/Zstack0145_green
+/acquisition/ROI_220_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x12230407"
 /acquisition/ROI_220_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_220_Red
@@ -6600,6 +7039,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_220_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_220_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_220_Red/imaging_plane -> /general/optophysiology/Zstack0145_red
+/acquisition/ROI_220_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x12230407"
 /acquisition/ROI_220_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_221_Green
@@ -6615,6 +7055,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_221_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_221_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_221_Green/imaging_plane -> /general/optophysiology/Zstack0149_green
+/acquisition/ROI_221_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x16ea04d9"
 /acquisition/ROI_221_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_221_Red
@@ -6630,6 +7071,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_221_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_221_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_221_Red/imaging_plane -> /general/optophysiology/Zstack0149_red
+/acquisition/ROI_221_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x16ea04d9"
 /acquisition/ROI_221_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_222_Green
@@ -6645,6 +7087,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_222_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_222_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_222_Green/imaging_plane -> /general/optophysiology/Zstack0149_green
+/acquisition/ROI_222_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x1bb105ab"
 /acquisition/ROI_222_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_222_Red
@@ -6660,6 +7103,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_222_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_222_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_222_Red/imaging_plane -> /general/optophysiology/Zstack0149_red
+/acquisition/ROI_222_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x1bb105ab"
 /acquisition/ROI_222_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_223_Green
@@ -6675,6 +7119,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_223_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_223_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_223_Green/imaging_plane -> /general/optophysiology/Zstack0149_green
+/acquisition/ROI_223_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xb890281"
 /acquisition/ROI_223_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_223_Red
@@ -6690,6 +7135,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_223_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_223_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_223_Red/imaging_plane -> /general/optophysiology/Zstack0149_red
+/acquisition/ROI_223_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xb890281"
 /acquisition/ROI_223_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_224_Green
@@ -6705,6 +7151,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_224_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_224_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_224_Green/imaging_plane -> /general/optophysiology/Zstack0150_green
+/acquisition/ROI_224_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x10500353"
 /acquisition/ROI_224_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_224_Red
@@ -6720,6 +7167,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_224_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_224_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_224_Red/imaging_plane -> /general/optophysiology/Zstack0150_red
+/acquisition/ROI_224_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x10500353"
 /acquisition/ROI_224_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_225_Green
@@ -6735,6 +7183,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_225_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_225_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_225_Green/imaging_plane -> /general/optophysiology/Zstack0150_green
+/acquisition/ROI_225_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x101b0326"
 /acquisition/ROI_225_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_225_Red
@@ -6750,6 +7199,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_225_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_225_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_225_Red/imaging_plane -> /general/optophysiology/Zstack0150_red
+/acquisition/ROI_225_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x101b0326"
 /acquisition/ROI_225_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_226_Green
@@ -6765,6 +7215,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_226_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_226_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_226_Green/imaging_plane -> /general/optophysiology/Zstack0150_green
+/acquisition/ROI_226_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x14ea03f9"
 /acquisition/ROI_226_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_226_Red
@@ -6780,6 +7231,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_226_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_226_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_226_Red/imaging_plane -> /general/optophysiology/Zstack0150_red
+/acquisition/ROI_226_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x14ea03f9"
 /acquisition/ROI_226_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_227_Green
@@ -6795,6 +7247,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_227_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_227_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_227_Green/imaging_plane -> /general/optophysiology/Zstack0153_green
+/acquisition/ROI_227_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xdbb02cd"
 /acquisition/ROI_227_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_227_Red
@@ -6810,6 +7263,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_227_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_227_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_227_Red/imaging_plane -> /general/optophysiology/Zstack0153_red
+/acquisition/ROI_227_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xdbb02cd"
 /acquisition/ROI_227_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_228_Green
@@ -6825,6 +7279,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_228_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_228_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_228_Green/imaging_plane -> /general/optophysiology/Zstack0153_green
+/acquisition/ROI_228_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x167f049e"
 /acquisition/ROI_228_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_228_Red
@@ -6840,6 +7295,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_228_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_228_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_228_Red/imaging_plane -> /general/optophysiology/Zstack0153_red
+/acquisition/ROI_228_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x167f049e"
 /acquisition/ROI_228_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_229_Green
@@ -6855,6 +7311,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_229_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_229_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_229_Green/imaging_plane -> /general/optophysiology/Zstack0153_green
+/acquisition/ROI_229_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x1b460570"
 /acquisition/ROI_229_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_229_Red
@@ -6870,6 +7327,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_229_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_229_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_229_Red/imaging_plane -> /general/optophysiology/Zstack0153_red
+/acquisition/ROI_229_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x1b460570"
 /acquisition/ROI_229_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_230_Green
@@ -6885,6 +7343,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_230_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_230_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_230_Green/imaging_plane -> /general/optophysiology/Zstack0153_green
+/acquisition/ROI_230_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xc1e0345"
 /acquisition/ROI_230_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_230_Red
@@ -6900,6 +7359,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_230_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_230_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_230_Red/imaging_plane -> /general/optophysiology/Zstack0153_red
+/acquisition/ROI_230_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xc1e0345"
 /acquisition/ROI_230_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_231_Green
@@ -6915,6 +7375,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_231_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_231_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_231_Green/imaging_plane -> /general/optophysiology/Zstack0168_green
+/acquisition/ROI_231_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x148c03ea"
 /acquisition/ROI_231_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_231_Red
@@ -6930,6 +7391,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_231_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_231_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_231_Red/imaging_plane -> /general/optophysiology/Zstack0168_red
+/acquisition/ROI_231_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x148c03ea"
 /acquisition/ROI_231_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_232_Green
@@ -6945,6 +7407,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_232_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_232_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_232_Green/imaging_plane -> /general/optophysiology/Zstack0168_green
+/acquisition/ROI_232_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xefa02d5"
 /acquisition/ROI_232_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_232_Red
@@ -6960,6 +7423,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_232_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_232_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_232_Red/imaging_plane -> /general/optophysiology/Zstack0168_red
+/acquisition/ROI_232_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xefa02d5"
 /acquisition/ROI_232_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_233_Green
@@ -6975,6 +7439,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_233_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_233_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_233_Green/imaging_plane -> /general/optophysiology/Zstack0168_green
+/acquisition/ROI_233_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x145703bd"
 /acquisition/ROI_233_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_233_Red
@@ -6990,6 +7455,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_233_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_233_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_233_Red/imaging_plane -> /general/optophysiology/Zstack0168_red
+/acquisition/ROI_233_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x145703bd"
 /acquisition/ROI_233_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_234_Green
@@ -7005,6 +7471,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_234_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_234_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_234_Green/imaging_plane -> /general/optophysiology/Zstack0168_green
+/acquisition/ROI_234_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xcc702a8"
 /acquisition/ROI_234_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_234_Red
@@ -7020,6 +7487,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_234_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_234_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_234_Red/imaging_plane -> /general/optophysiology/Zstack0168_red
+/acquisition/ROI_234_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xcc702a8"
 /acquisition/ROI_234_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_235_Green
@@ -7035,6 +7503,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_235_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_235_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_235_Green/imaging_plane -> /general/optophysiology/Zstack0168_green
+/acquisition/ROI_235_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xc290291"
 /acquisition/ROI_235_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_235_Red
@@ -7050,6 +7519,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_235_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_235_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_235_Red/imaging_plane -> /general/optophysiology/Zstack0168_red
+/acquisition/ROI_235_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xc290291"
 /acquisition/ROI_235_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_236_Green
@@ -7065,6 +7535,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_236_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_236_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_236_Green/imaging_plane -> /general/optophysiology/Zstack0168_green
+/acquisition/ROI_236_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x158b0479"
 /acquisition/ROI_236_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_236_Red
@@ -7080,6 +7551,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_236_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_236_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_236_Red/imaging_plane -> /general/optophysiology/Zstack0168_red
+/acquisition/ROI_236_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x158b0479"
 /acquisition/ROI_236_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_237_Green
@@ -7095,6 +7567,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_237_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_237_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_237_Green/imaging_plane -> /general/optophysiology/Zstack0168_green
+/acquisition/ROI_237_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xff90364"
 /acquisition/ROI_237_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_237_Red
@@ -7110,6 +7583,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_237_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_237_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_237_Red/imaging_plane -> /general/optophysiology/Zstack0168_red
+/acquisition/ROI_237_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xff90364"
 /acquisition/ROI_237_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_238_Green
@@ -7125,6 +7599,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_238_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_238_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_238_Green/imaging_plane -> /general/optophysiology/Zstack0168_green
+/acquisition/ROI_238_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x1556044c"
 /acquisition/ROI_238_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_238_Red
@@ -7140,6 +7615,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_238_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_238_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_238_Red/imaging_plane -> /general/optophysiology/Zstack0168_red
+/acquisition/ROI_238_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x1556044c"
 /acquisition/ROI_238_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_239_Green
@@ -7155,6 +7631,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_239_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_239_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_239_Green/imaging_plane -> /general/optophysiology/Zstack0168_green
+/acquisition/ROI_239_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x14c00436"
 /acquisition/ROI_239_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_239_Red
@@ -7170,6 +7647,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_239_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_239_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_239_Red/imaging_plane -> /general/optophysiology/Zstack0168_red
+/acquisition/ROI_239_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x14c00436"
 /acquisition/ROI_239_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_240_Green
@@ -7185,6 +7663,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_240_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_240_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_240_Green/imaging_plane -> /general/optophysiology/Zstack0168_green
+/acquisition/ROI_240_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x1a1d051e"
 /acquisition/ROI_240_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_240_Red
@@ -7200,6 +7679,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_240_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_240_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_240_Red/imaging_plane -> /general/optophysiology/Zstack0168_red
+/acquisition/ROI_240_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x1a1d051e"
 /acquisition/ROI_240_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_241_Green
@@ -7215,6 +7695,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_241_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_241_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_241_Green/imaging_plane -> /general/optophysiology/Zstack0168_green
+/acquisition/ROI_241_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x19870508"
 /acquisition/ROI_241_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_241_Red
@@ -7230,6 +7711,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_241_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_241_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_241_Red/imaging_plane -> /general/optophysiology/Zstack0168_red
+/acquisition/ROI_241_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x19870508"
 /acquisition/ROI_241_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_242_Green
@@ -7245,6 +7727,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_242_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_242_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_242_Green/imaging_plane -> /general/optophysiology/Zstack0168_green
+/acquisition/ROI_242_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x12ee03f2"
 /acquisition/ROI_242_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_242_Red
@@ -7260,6 +7743,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_242_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_242_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_242_Red/imaging_plane -> /general/optophysiology/Zstack0168_red
+/acquisition/ROI_242_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x12ee03f2"
 /acquisition/ROI_242_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_243_Green
@@ -7275,6 +7759,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_243_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_243_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_243_Green/imaging_plane -> /general/optophysiology/Zstack0168_green
+/acquisition/ROI_243_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x125803dc"
 /acquisition/ROI_243_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_243_Red
@@ -7290,6 +7775,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_243_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_243_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_243_Red/imaging_plane -> /general/optophysiology/Zstack0168_red
+/acquisition/ROI_243_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x125803dc"
 /acquisition/ROI_243_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_244_Green
@@ -7305,6 +7791,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_244_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_244_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_244_Green/imaging_plane -> /general/optophysiology/Zstack0168_green
+/acquisition/ROI_244_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x17bd04c5"
 /acquisition/ROI_244_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_244_Red
@@ -7320,6 +7807,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_244_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_244_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_244_Red/imaging_plane -> /general/optophysiology/Zstack0168_red
+/acquisition/ROI_244_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x17bd04c5"
 /acquisition/ROI_244_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_245_Green
@@ -7335,6 +7823,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_245_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_245_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_245_Green/imaging_plane -> /general/optophysiology/Zstack0168_green
+/acquisition/ROI_245_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x171f04ae"
 /acquisition/ROI_245_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_245_Red
@@ -7350,6 +7839,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_245_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_245_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_245_Red/imaging_plane -> /general/optophysiology/Zstack0168_red
+/acquisition/ROI_245_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x171f04ae"
 /acquisition/ROI_245_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_246_Green
@@ -7365,6 +7855,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_246_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_246_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_246_Green/imaging_plane -> /general/optophysiology/Zstack0163_green
+/acquisition/ROI_246_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x16890498"
 /acquisition/ROI_246_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_246_Red
@@ -7380,6 +7871,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_246_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_246_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_246_Red/imaging_plane -> /general/optophysiology/Zstack0163_red
+/acquisition/ROI_246_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x16890498"
 /acquisition/ROI_246_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_247_Green
@@ -7395,6 +7887,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_247_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_247_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_247_Green/imaging_plane -> /general/optophysiology/Zstack0163_green
+/acquisition/ROI_247_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xef10382"
 /acquisition/ROI_247_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_247_Red
@@ -7410,6 +7903,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_247_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_247_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_247_Red/imaging_plane -> /general/optophysiology/Zstack0163_red
+/acquisition/ROI_247_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xef10382"
 /acquisition/ROI_247_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_248_Green
@@ -7425,6 +7919,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_248_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_248_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_248_Green/imaging_plane -> /general/optophysiology/Zstack0163_green
+/acquisition/ROI_248_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xb5d026d"
 /acquisition/ROI_248_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_248_Red
@@ -7440,6 +7935,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_248_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_248_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_248_Red/imaging_plane -> /general/optophysiology/Zstack0163_red
+/acquisition/ROI_248_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xb5d026d"
 /acquisition/ROI_248_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_249_Green
@@ -7455,6 +7951,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_249_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_249_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_249_Green/imaging_plane -> /general/optophysiology/Zstack0141_green
+/acquisition/ROI_249_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x9c00256"
 /acquisition/ROI_249_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_249_Red
@@ -7470,6 +7967,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_249_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_249_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_249_Red/imaging_plane -> /general/optophysiology/Zstack0141_red
+/acquisition/ROI_249_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x9c00256"
 /acquisition/ROI_249_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_250_Green
@@ -7485,6 +7983,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_250_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_250_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_250_Green/imaging_plane -> /general/optophysiology/Zstack0141_green
+/acquisition/ROI_250_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x92a0240"
 /acquisition/ROI_250_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_250_Red
@@ -7500,6 +7999,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_250_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_250_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_250_Red/imaging_plane -> /general/optophysiology/Zstack0141_red
+/acquisition/ROI_250_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x92a0240"
 /acquisition/ROI_250_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_251_Green
@@ -7515,6 +8015,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_251_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_251_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_251_Green/imaging_plane -> /general/optophysiology/Zstack0141_green
+/acquisition/ROI_251_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xe870328"
 /acquisition/ROI_251_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_251_Red
@@ -7530,6 +8031,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_251_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_251_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_251_Red/imaging_plane -> /general/optophysiology/Zstack0141_red
+/acquisition/ROI_251_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xe870328"
 /acquisition/ROI_251_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_252_Green
@@ -7545,6 +8047,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_252_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_252_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_252_Green/imaging_plane -> /general/optophysiology/Zstack0144_green
+/acquisition/ROI_252_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x8f50213"
 /acquisition/ROI_252_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_252_Red
@@ -7560,6 +8063,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_252_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_252_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_252_Red/imaging_plane -> /general/optophysiology/Zstack0144_red
+/acquisition/ROI_252_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x8f50213"
 /acquisition/ROI_252_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_253_Green
@@ -7575,6 +8079,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_253_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_253_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_253_Green/imaging_plane -> /general/optophysiology/Zstack0144_green
+/acquisition/ROI_253_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xe5a02fc"
 /acquisition/ROI_253_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_253_Red
@@ -7590,6 +8095,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_253_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_253_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_253_Red/imaging_plane -> /general/optophysiology/Zstack0144_red
+/acquisition/ROI_253_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xe5a02fc"
 /acquisition/ROI_253_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_254_Green
@@ -7605,6 +8111,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_254_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_254_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_254_Green/imaging_plane -> /general/optophysiology/Zstack0137_green
+/acquisition/ROI_254_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x11b903e4"
 /acquisition/ROI_254_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_254_Red
@@ -7620,6 +8127,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_254_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_254_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_254_Red/imaging_plane -> /general/optophysiology/Zstack0137_red
+/acquisition/ROI_254_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x11b903e4"
 /acquisition/ROI_254_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_255_Green
@@ -7635,6 +8143,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_255_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_255_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_255_Green/imaging_plane -> /general/optophysiology/Zstack0137_green
+/acquisition/ROI_255_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x171e04cd"
 /acquisition/ROI_255_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_255_Red
@@ -7650,6 +8159,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_255_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_255_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_255_Red/imaging_plane -> /general/optophysiology/Zstack0137_red
+/acquisition/ROI_255_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x171e04cd"
 /acquisition/ROI_255_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_256_Green
@@ -7665,6 +8175,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_256_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_256_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_256_Green/imaging_plane -> /general/optophysiology/Zstack0137_green
+/acquisition/ROI_256_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x168004b6"
 /acquisition/ROI_256_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_256_Red
@@ -7680,6 +8191,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_256_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_256_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_256_Red/imaging_plane -> /general/optophysiology/Zstack0137_red
+/acquisition/ROI_256_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x168004b6"
 /acquisition/ROI_256_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_257_Green
@@ -7695,6 +8207,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_257_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_257_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_257_Green/imaging_plane -> /general/optophysiology/Zstack0136_green
+/acquisition/ROI_257_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xfef03a1"
 /acquisition/ROI_257_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_257_Red
@@ -7710,6 +8223,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_257_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_257_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_257_Red/imaging_plane -> /general/optophysiology/Zstack0136_red
+/acquisition/ROI_257_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xfef03a1"
 /acquisition/ROI_257_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_258_Green
@@ -7725,6 +8239,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_258_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_258_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_258_Green/imaging_plane -> /general/optophysiology/Zstack0136_green
+/acquisition/ROI_258_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xf51038a"
 /acquisition/ROI_258_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_258_Red
@@ -7740,6 +8255,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_258_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_258_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_258_Red/imaging_plane -> /general/optophysiology/Zstack0136_red
+/acquisition/ROI_258_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xf51038a"
 /acquisition/ROI_258_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_259_Green
@@ -7755,6 +8271,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_259_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_259_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_259_Green/imaging_plane -> /general/optophysiology/Zstack0136_green
+/acquisition/ROI_259_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xebb0374"
 /acquisition/ROI_259_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_259_Red
@@ -7770,6 +8287,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_259_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_259_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_259_Red/imaging_plane -> /general/optophysiology/Zstack0136_red
+/acquisition/ROI_259_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xebb0374"
 /acquisition/ROI_259_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_260_Green
@@ -7785,6 +8303,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_260_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_260_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_260_Green/imaging_plane -> /general/optophysiology/Zstack0103_green
+/acquisition/ROI_260_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x1420045d"
 /acquisition/ROI_260_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_260_Red
@@ -7800,6 +8319,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_260_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_260_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_260_Red/imaging_plane -> /general/optophysiology/Zstack0103_red
+/acquisition/ROI_260_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x1420045d"
 /acquisition/ROI_260_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_261_Green
@@ -7815,6 +8335,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_261_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_261_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_261_Green/imaging_plane -> /general/optophysiology/Zstack0103_green
+/acquisition/ROI_261_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xe860347"
 /acquisition/ROI_261_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_261_Red
@@ -7830,6 +8351,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_261_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_261_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_261_Red/imaging_plane -> /general/optophysiology/Zstack0103_red
+/acquisition/ROI_261_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xe860347"
 /acquisition/ROI_261_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_262_Green
@@ -7845,6 +8367,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_262_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_262_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_262_Green/imaging_plane -> /general/optophysiology/Zstack0103_green
+/acquisition/ROI_262_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x13eb0430"
 /acquisition/ROI_262_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_262_Red
@@ -7860,6 +8383,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_262_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_262_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_262_Red/imaging_plane -> /general/optophysiology/Zstack0103_red
+/acquisition/ROI_262_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x13eb0430"
 /acquisition/ROI_262_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_263_Green
@@ -7875,6 +8399,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_263_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_263_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_263_Green/imaging_plane -> /general/optophysiology/Zstack0103_green
+/acquisition/ROI_263_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x134d0419"
 /acquisition/ROI_263_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_263_Red
@@ -7890,6 +8415,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_263_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_263_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_263_Red/imaging_plane -> /general/optophysiology/Zstack0103_red
+/acquisition/ROI_263_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x134d0419"
 /acquisition/ROI_263_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_264_Green
@@ -7905,6 +8431,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_264_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_264_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_264_Green/imaging_plane -> /general/optophysiology/Zstack0103_green
+/acquisition/ROI_264_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x11b80403"
 /acquisition/ROI_264_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_264_Red
@@ -7920,6 +8447,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_264_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_264_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_264_Red/imaging_plane -> /general/optophysiology/Zstack0103_red
+/acquisition/ROI_264_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x11b80403"
 /acquisition/ROI_264_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_265_Green
@@ -7935,6 +8463,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_265_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_265_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_265_Green/imaging_plane -> /general/optophysiology/Zstack0103_green
+/acquisition/ROI_265_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x111a03ec"
 /acquisition/ROI_265_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_265_Red
@@ -7950,6 +8479,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_265_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_265_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_265_Red/imaging_plane -> /general/optophysiology/Zstack0103_red
+/acquisition/ROI_265_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x111a03ec"
 /acquisition/ROI_265_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_266_Green
@@ -7965,6 +8495,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_266_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_266_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_266_Green/imaging_plane -> /general/optophysiology/Zstack0103_green
+/acquisition/ROI_266_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xe8502d7"
 /acquisition/ROI_266_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_266_Red
@@ -7980,6 +8511,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_266_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_266_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_266_Red/imaging_plane -> /general/optophysiology/Zstack0103_red
+/acquisition/ROI_266_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xe8502d7"
 /acquisition/ROI_266_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_267_Green
@@ -7995,6 +8527,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_267_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_267_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_267_Green/imaging_plane -> /general/optophysiology/Zstack0103_green
+/acquisition/ROI_267_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xdef02c1"
 /acquisition/ROI_267_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_267_Red
@@ -8010,6 +8543,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_267_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_267_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_267_Red/imaging_plane -> /general/optophysiology/Zstack0103_red
+/acquisition/ROI_267_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xdef02c1"
 /acquisition/ROI_267_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_268_Green
@@ -8025,6 +8559,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_268_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_268_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_268_Green/imaging_plane -> /general/optophysiology/Zstack0103_green
+/acquisition/ROI_268_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x134c03a9"
 /acquisition/ROI_268_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_268_Red
@@ -8040,6 +8575,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_268_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_268_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_268_Red/imaging_plane -> /general/optophysiology/Zstack0103_red
+/acquisition/ROI_268_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x134c03a9"
 /acquisition/ROI_268_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_269_Green
@@ -8055,6 +8591,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_269_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_269_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_269_Green/imaging_plane -> /general/optophysiology/Zstack0103_green
+/acquisition/ROI_269_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x12b60393"
 /acquisition/ROI_269_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_269_Red
@@ -8070,6 +8607,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_269_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_269_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_269_Red/imaging_plane -> /general/optophysiology/Zstack0103_red
+/acquisition/ROI_269_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x12b60393"
 /acquisition/ROI_269_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_270_Green
@@ -8085,6 +8623,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_270_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_270_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_270_Green/imaging_plane -> /general/optophysiology/Zstack0097_green
+/acquisition/ROI_270_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x1218037c"
 /acquisition/ROI_270_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_270_Red
@@ -8100,6 +8639,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_270_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_270_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_270_Red/imaging_plane -> /general/optophysiology/Zstack0097_red
+/acquisition/ROI_270_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x1218037c"
 /acquisition/ROI_270_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_271_Green
@@ -8115,6 +8655,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_271_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_271_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_271_Green/imaging_plane -> /general/optophysiology/Zstack0097_green
+/acquisition/ROI_271_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x167e0465"
 /acquisition/ROI_271_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_271_Red
@@ -8130,6 +8671,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_271_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_271_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_271_Red/imaging_plane -> /general/optophysiology/Zstack0097_red
+/acquisition/ROI_271_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x167e0465"
 /acquisition/ROI_271_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_272_Green
@@ -8145,6 +8687,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_272_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_272_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_272_Green/imaging_plane -> /general/optophysiology/Zstack0097_green
+/acquisition/ROI_272_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xee6034f"
 /acquisition/ROI_272_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_272_Red
@@ -8160,6 +8703,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_272_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_272_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_272_Red/imaging_plane -> /general/optophysiology/Zstack0097_red
+/acquisition/ROI_272_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xee6034f"
 /acquisition/ROI_272_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_273_Green
@@ -8175,6 +8719,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_273_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_273_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_273_Green/imaging_plane -> /general/optophysiology/Zstack0097_green
+/acquisition/ROI_273_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x144b0438"
 /acquisition/ROI_273_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_273_Red
@@ -8190,6 +8735,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_273_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_273_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_273_Red/imaging_plane -> /general/optophysiology/Zstack0097_red
+/acquisition/ROI_273_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x144b0438"
 /acquisition/ROI_273_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_274_Green
@@ -8205,6 +8751,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_274_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_274_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_274_Green/imaging_plane -> /general/optophysiology/Zstack0097_green
+/acquisition/ROI_274_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x13b50422"
 /acquisition/ROI_274_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_274_Red
@@ -8220,6 +8767,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_274_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_274_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_274_Red/imaging_plane -> /general/optophysiology/Zstack0097_red
+/acquisition/ROI_274_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x13b50422"
 /acquisition/ROI_274_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_275_Green
@@ -8235,6 +8783,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_275_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_275_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_275_Green/imaging_plane -> /general/optophysiology/Zstack0097_green
+/acquisition/ROI_275_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x1912050a"
 /acquisition/ROI_275_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_275_Red
@@ -8250,6 +8799,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_275_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_275_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_275_Red/imaging_plane -> /general/optophysiology/Zstack0097_red
+/acquisition/ROI_275_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x1912050a"
 /acquisition/ROI_275_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_276_Green
@@ -8265,6 +8815,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_276_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_276_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_276_Green/imaging_plane -> /general/optophysiology/Zstack0097_green
+/acquisition/ROI_276_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x138003f5"
 /acquisition/ROI_276_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_276_Red
@@ -8280,6 +8831,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_276_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_276_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_276_Red/imaging_plane -> /general/optophysiology/Zstack0097_red
+/acquisition/ROI_276_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x138003f5"
 /acquisition/ROI_276_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_277_Green
@@ -8295,6 +8847,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_277_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_277_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_277_Green/imaging_plane -> /general/optophysiology/Zstack0097_green
+/acquisition/ROI_277_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x18dd04dd"
 /acquisition/ROI_277_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_277_Red
@@ -8310,6 +8863,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_277_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_277_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_277_Red/imaging_plane -> /general/optophysiology/Zstack0097_red
+/acquisition/ROI_277_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x18dd04dd"
 /acquisition/ROI_277_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_278_Green
@@ -8325,6 +8879,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_278_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_278_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_278_Green/imaging_plane -> /general/optophysiology/Zstack0097_green
+/acquisition/ROI_278_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x184704c7"
 /acquisition/ROI_278_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_278_Red
@@ -8340,6 +8895,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_278_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_278_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_278_Red/imaging_plane -> /general/optophysiology/Zstack0097_red
+/acquisition/ROI_278_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x184704c7"
 /acquisition/ROI_278_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_279_Green
@@ -8355,6 +8911,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_279_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_279_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_279_Green/imaging_plane -> /general/optophysiology/Zstack0097_green
+/acquisition/ROI_279_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x16aa04b0"
 /acquisition/ROI_279_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_279_Red
@@ -8370,6 +8927,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_279_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_279_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_279_Red/imaging_plane -> /general/optophysiology/Zstack0097_red
+/acquisition/ROI_279_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x16aa04b0"
 /acquisition/ROI_279_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_280_Green
@@ -8385,6 +8943,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_280_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_280_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_280_Green/imaging_plane -> /general/optophysiology/Zstack0168_green
+/acquisition/ROI_280_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x1614049a"
 /acquisition/ROI_280_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_280_Red
@@ -8400,6 +8959,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_280_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_280_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_280_Red/imaging_plane -> /general/optophysiology/Zstack0168_red
+/acquisition/ROI_280_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x1614049a"
 /acquisition/ROI_280_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_281_Green
@@ -8415,6 +8975,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_281_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_281_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_281_Green/imaging_plane -> /general/optophysiology/Zstack0168_green
+/acquisition/ROI_281_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x8890286"
 /acquisition/ROI_281_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_281_Red
@@ -8430,6 +8991,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_281_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_281_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_281_Red/imaging_plane -> /general/optophysiology/Zstack0168_red
+/acquisition/ROI_281_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x8890286"
 /acquisition/ROI_281_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_282_Green
@@ -8445,6 +9007,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_282_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_282_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_282_Green/imaging_plane -> /general/optophysiology/Zstack0167_green
+/acquisition/ROI_282_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xde6036e"
 /acquisition/ROI_282_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_282_Red
@@ -8460,6 +9023,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_282_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_282_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_282_Red/imaging_plane -> /general/optophysiology/Zstack0167_red
+/acquisition/ROI_282_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xde6036e"
 /acquisition/ROI_282_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_283_Green
@@ -8475,6 +9039,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_283_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_283_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_283_Green/imaging_plane -> /general/optophysiology/Zstack0167_green
+/acquisition/ROI_283_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xa520259"
 /acquisition/ROI_283_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_283_Red
@@ -8490,6 +9055,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_283_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_283_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_283_Red/imaging_plane -> /general/optophysiology/Zstack0167_red
+/acquisition/ROI_283_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xa520259"
 /acquisition/ROI_283_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_284_Green
@@ -8505,6 +9071,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_284_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_284_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_284_Green/imaging_plane -> /general/optophysiology/Zstack0165_green
+/acquisition/ROI_284_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xfaf0341"
 /acquisition/ROI_284_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_284_Red
@@ -8520,6 +9087,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_284_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_284_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_284_Red/imaging_plane -> /general/optophysiology/Zstack0165_red
+/acquisition/ROI_284_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xfaf0341"
 /acquisition/ROI_284_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_285_Green
@@ -8535,6 +9103,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_285_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_285_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_285_Green/imaging_plane -> /general/optophysiology/Zstack0149_green
+/acquisition/ROI_285_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xf19032b"
 /acquisition/ROI_285_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_285_Red
@@ -8550,6 +9119,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_285_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_285_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_285_Red/imaging_plane -> /general/optophysiology/Zstack0149_red
+/acquisition/ROI_285_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xf19032b"
 /acquisition/ROI_285_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_286_Green
@@ -8565,6 +9135,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_286_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_286_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_286_Green/imaging_plane -> /general/optophysiology/Zstack0149_green
+/acquisition/ROI_286_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xf7a0314"
 /acquisition/ROI_286_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_286_Red
@@ -8580,6 +9151,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_286_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_286_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_286_Red/imaging_plane -> /general/optophysiology/Zstack0149_red
+/acquisition/ROI_286_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xf7a0314"
 /acquisition/ROI_286_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_287_Green
@@ -8595,6 +9167,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_287_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_287_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_287_Green/imaging_plane -> /general/optophysiology/Zstack0149_green
+/acquisition/ROI_287_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x7ea01ff"
 /acquisition/ROI_287_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_287_Red
@@ -8610,6 +9183,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_287_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_287_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_287_Red/imaging_plane -> /general/optophysiology/Zstack0149_red
+/acquisition/ROI_287_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x7ea01ff"
 /acquisition/ROI_287_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_288_Green
@@ -8625,6 +9199,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_288_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_288_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_288_Green/imaging_plane -> /general/optophysiology/Zstack0148_green
+/acquisition/ROI_288_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x114c03e7"
 /acquisition/ROI_288_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_288_Red
@@ -8640,6 +9215,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_288_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_288_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_288_Red/imaging_plane -> /general/optophysiology/Zstack0148_red
+/acquisition/ROI_288_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x114c03e7"
 /acquisition/ROI_288_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_289_Green
@@ -8655,6 +9231,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_289_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_289_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_289_Green/imaging_plane -> /general/optophysiology/Zstack0148_green
+/acquisition/ROI_289_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x10ae03d0"
 /acquisition/ROI_289_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_289_Red
@@ -8670,6 +9247,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_289_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_289_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_289_Red/imaging_plane -> /general/optophysiology/Zstack0148_red
+/acquisition/ROI_289_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x10ae03d0"
 /acquisition/ROI_289_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_290_Green
@@ -8685,6 +9263,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_290_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_290_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_290_Green/imaging_plane -> /general/optophysiology/Zstack0110_green
+/acquisition/ROI_290_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x161304b9"
 /acquisition/ROI_290_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_290_Red
@@ -8700,6 +9279,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_290_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_290_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_290_Red/imaging_plane -> /general/optophysiology/Zstack0110_red
+/acquisition/ROI_290_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x161304b9"
 /acquisition/ROI_290_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_291_Green
@@ -8715,6 +9295,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_291_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_291_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_291_Green/imaging_plane -> /general/optophysiology/Zstack0110_green
+/acquisition/ROI_291_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x107903a3"
 /acquisition/ROI_291_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_291_Red
@@ -8730,6 +9311,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_291_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_291_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_291_Red/imaging_plane -> /general/optophysiology/Zstack0110_red
+/acquisition/ROI_291_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x107903a3"
 /acquisition/ROI_291_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_292_Green
@@ -8745,6 +9327,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_292_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_292_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_292_Green/imaging_plane -> /general/optophysiology/Zstack0110_green
+/acquisition/ROI_292_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xfe3038d"
 /acquisition/ROI_292_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_292_Red
@@ -8760,6 +9343,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_292_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_292_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_292_Red/imaging_plane -> /general/optophysiology/Zstack0110_red
+/acquisition/ROI_292_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xfe3038d"
 /acquisition/ROI_292_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_293_Green
@@ -8775,6 +9359,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_293_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_293_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_293_Green/imaging_plane -> /general/optophysiology/Zstack0110_green
+/acquisition/ROI_293_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x15400475"
 /acquisition/ROI_293_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_293_Red
@@ -8790,6 +9375,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_293_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_293_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_293_Red/imaging_plane -> /general/optophysiology/Zstack0110_red
+/acquisition/ROI_293_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x15400475"
 /acquisition/ROI_293_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_294_Green
@@ -8805,6 +9391,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_294_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_294_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_294_Green/imaging_plane -> /general/optophysiology/Zstack0110_green
+/acquisition/ROI_294_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xdb00360"
 /acquisition/ROI_294_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_294_Red
@@ -8820,6 +9407,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_294_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_294_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_294_Red/imaging_plane -> /general/optophysiology/Zstack0110_red
+/acquisition/ROI_294_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xdb00360"
 /acquisition/ROI_294_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_295_Green
@@ -8835,6 +9423,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_295_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_295_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_295_Green/imaging_plane -> /general/optophysiology/Zstack0110_green
+/acquisition/ROI_295_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x13150449"
 /acquisition/ROI_295_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_295_Red
@@ -8850,6 +9439,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_295_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_295_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_295_Red/imaging_plane -> /general/optophysiology/Zstack0110_red
+/acquisition/ROI_295_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x13150449"
 /acquisition/ROI_295_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_296_Green
@@ -8865,6 +9455,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_296_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_296_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_296_Green/imaging_plane -> /general/optophysiology/Zstack0110_green
+/acquisition/ROI_296_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xd7b0333"
 /acquisition/ROI_296_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_296_Red
@@ -8880,6 +9471,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_296_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_296_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_296_Red/imaging_plane -> /general/optophysiology/Zstack0110_red
+/acquisition/ROI_296_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xd7b0333"
 /acquisition/ROI_296_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_297_Green
@@ -8895,6 +9487,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_297_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_297_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_297_Green/imaging_plane -> /general/optophysiology/Zstack0110_green
+/acquisition/ROI_297_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x12e0041c"
 /acquisition/ROI_297_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_297_Red
@@ -8910,6 +9503,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_297_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_297_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_297_Red/imaging_plane -> /general/optophysiology/Zstack0110_red
+/acquisition/ROI_297_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x12e0041c"
 /acquisition/ROI_297_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_298_Green
@@ -8925,6 +9519,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_298_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_298_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_298_Green/imaging_plane -> /general/optophysiology/Zstack0122_green
+/acquisition/ROI_298_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x12420405"
 /acquisition/ROI_298_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_298_Red
@@ -8940,6 +9535,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_298_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_298_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_298_Red/imaging_plane -> /general/optophysiology/Zstack0122_red
+/acquisition/ROI_298_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x12420405"
 /acquisition/ROI_298_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_299_Green
@@ -8955,6 +9551,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_299_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_299_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_299_Green/imaging_plane -> /general/optophysiology/Zstack0122_green
+/acquisition/ROI_299_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x17a704ee"
 /acquisition/ROI_299_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_299_Red
@@ -8970,6 +9567,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_299_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_299_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_299_Red/imaging_plane -> /general/optophysiology/Zstack0122_red
+/acquisition/ROI_299_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x17a704ee"
 /acquisition/ROI_299_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_300_Green
@@ -8985,6 +9583,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_300_Green/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_300_Green/format: dtype=object shape=() val="raw"
 /acquisition/ROI_300_Green/imaging_plane -> /general/optophysiology/Zstack0122_green
+/acquisition/ROI_300_Green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xf0f02d9"
 /acquisition/ROI_300_Green/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/ROI_300_Red
@@ -9000,6 +9599,7 @@ Generating signature for 170714_22_26_27.nwb
 /acquisition/ROI_300_Red/field_of_view: dtype=float64 shape=(2,) val="0x5be609eb"
 /acquisition/ROI_300_Red/format: dtype=object shape=() val="raw"
 /acquisition/ROI_300_Red/imaging_plane -> /general/optophysiology/Zstack0122_red
+/acquisition/ROI_300_Red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xf0f02d9"
 /acquisition/ROI_300_Red/timestamps: dtype=float64 shape=(46820,) val="0x295617cb"
 	@unit: type=str val="seconds"
 /acquisition/Zstack_Green_0001
@@ -18098,6 +18698,7 @@ Generating signature for 170714_22_26_27.nwb
 /general/optophysiology/Zstack0168_red/reference_frame: dtype=object shape=() val="TODO: In lab book (partly?)"
 /general/session_id: dtype=object shape=() val="170714_22_26_27"
 /general/silverlab_metadata
+	@labview_version: type=str val="pre-2018 (original)"
 	@silverlab_api_version: type=str val="0.2"
 /general/silverlab_optophysiology
 	@cycle_time: dtype=float64 shape=() val="0.00978735"
@@ -18132,7 +18733,7 @@ Generating signature for 170714_22_26_27.nwb
 /processing/Acquired_ROIs
 	@description: type=str val="ROI locations and acquired fluorescence readings made directly by the AOL microscope."
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0064_green
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0064_green/angle_deg: dtype=float64 shape=(10,) val="0x500001"
 	@description: type=str val="Angle (deg)"
@@ -18154,8 +18755,6 @@ Generating signature for 170714_22_26_27.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0064_green/pixel_mask_index: dtype=int64 shape=(10,) val="0x7300038"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0064_green/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0064_green/pixel_time_offsets: dtype=float64 shape=(10, 1) val="0x3fc922ad"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0064_green/reference_images/Zstack_Red_0064 -> /acquisition/Zstack_Red_0064
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0064_green/reference_images/reference_images -> /acquisition/Zstack_Red_0064
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0064_green/roi_group_id: dtype=float64 shape=(10,) val="0x500001"
@@ -18179,7 +18778,7 @@ Generating signature for 170714_22_26_27.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0064_green/zoom: dtype=float64 shape=(10,) val="0xbfad0bd7"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0064_red
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0064_red/angle_deg: dtype=float64 shape=(10,) val="0x500001"
 	@description: type=str val="Angle (deg)"
@@ -18201,8 +18800,6 @@ Generating signature for 170714_22_26_27.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0064_red/pixel_mask_index: dtype=int64 shape=(10,) val="0x7300038"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0064_red/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0064_red/pixel_time_offsets: dtype=float64 shape=(10, 1) val="0x3fc922ad"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0064_red/reference_images/Zstack_Red_0064 -> /acquisition/Zstack_Red_0064
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0064_red/reference_images/reference_images -> /acquisition/Zstack_Red_0064
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0064_red/roi_group_id: dtype=float64 shape=(10,) val="0x500001"
@@ -18226,7 +18823,7 @@ Generating signature for 170714_22_26_27.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0064_red/zoom: dtype=float64 shape=(10,) val="0xbfad0bd7"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0067_green
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0067_green/angle_deg: dtype=float64 shape=(9,) val="0x480001"
 	@description: type=str val="Angle (deg)"
@@ -18248,8 +18845,6 @@ Generating signature for 170714_22_26_27.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0067_green/pixel_mask_index: dtype=int64 shape=(9,) val="0x570002e"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0067_green/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0067_green/pixel_time_offsets: dtype=float64 shape=(9, 1) val="0xd4e41fee"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0067_green/reference_images/Zstack_Red_0067 -> /acquisition/Zstack_Red_0067
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0067_green/reference_images/reference_images -> /acquisition/Zstack_Red_0067
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0067_green/roi_group_id: dtype=float64 shape=(9,) val="0x480001"
@@ -18273,7 +18868,7 @@ Generating signature for 170714_22_26_27.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0067_green/zoom: dtype=float64 shape=(9,) val="0x684e0aa8"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0067_red
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0067_red/angle_deg: dtype=float64 shape=(9,) val="0x480001"
 	@description: type=str val="Angle (deg)"
@@ -18295,8 +18890,6 @@ Generating signature for 170714_22_26_27.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0067_red/pixel_mask_index: dtype=int64 shape=(9,) val="0x570002e"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0067_red/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0067_red/pixel_time_offsets: dtype=float64 shape=(9, 1) val="0xd4e41fee"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0067_red/reference_images/Zstack_Red_0067 -> /acquisition/Zstack_Red_0067
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0067_red/reference_images/reference_images -> /acquisition/Zstack_Red_0067
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0067_red/roi_group_id: dtype=float64 shape=(9,) val="0x480001"
@@ -18320,7 +18913,7 @@ Generating signature for 170714_22_26_27.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0067_red/zoom: dtype=float64 shape=(9,) val="0x684e0aa8"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0080_green
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0080_green/angle_deg: dtype=float64 shape=(5,) val="0x280001"
 	@description: type=str val="Angle (deg)"
@@ -18342,8 +18935,6 @@ Generating signature for 170714_22_26_27.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0080_green/pixel_mask_index: dtype=int64 shape=(5,) val="0x1400010"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0080_green/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0080_green/pixel_time_offsets: dtype=float64 shape=(5, 1) val="0xc55d14ab"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0080_green/reference_images/Zstack_Red_0080 -> /acquisition/Zstack_Red_0080
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0080_green/reference_images/reference_images -> /acquisition/Zstack_Red_0080
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0080_green/roi_group_id: dtype=float64 shape=(5,) val="0x280001"
@@ -18367,7 +18958,7 @@ Generating signature for 170714_22_26_27.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0080_green/zoom: dtype=float64 shape=(5,) val="0x697305ec"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0080_red
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0080_red/angle_deg: dtype=float64 shape=(5,) val="0x280001"
 	@description: type=str val="Angle (deg)"
@@ -18389,8 +18980,6 @@ Generating signature for 170714_22_26_27.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0080_red/pixel_mask_index: dtype=int64 shape=(5,) val="0x1400010"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0080_red/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0080_red/pixel_time_offsets: dtype=float64 shape=(5, 1) val="0xc55d14ab"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0080_red/reference_images/Zstack_Red_0080 -> /acquisition/Zstack_Red_0080
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0080_red/reference_images/reference_images -> /acquisition/Zstack_Red_0080
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0080_red/roi_group_id: dtype=float64 shape=(5,) val="0x280001"
@@ -18414,7 +19003,7 @@ Generating signature for 170714_22_26_27.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0080_red/zoom: dtype=float64 shape=(5,) val="0x697305ec"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0087_green
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0087_green/angle_deg: dtype=float64 shape=(4,) val="0x200001"
 	@description: type=str val="Angle (deg)"
@@ -18436,8 +19025,6 @@ Generating signature for 170714_22_26_27.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0087_green/pixel_mask_index: dtype=int64 shape=(4,) val="0xc0000b"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0087_green/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0087_green/pixel_time_offsets: dtype=float64 shape=(4, 1) val="0xe79e0e84"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0087_green/reference_images/Zstack_Red_0087 -> /acquisition/Zstack_Red_0087
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0087_green/reference_images/reference_images -> /acquisition/Zstack_Red_0087
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0087_green/roi_group_id: dtype=float64 shape=(4,) val="0x200001"
@@ -18461,7 +19048,7 @@ Generating signature for 170714_22_26_27.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0087_green/zoom: dtype=float64 shape=(4,) val="0x416c04bd"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0087_red
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0087_red/angle_deg: dtype=float64 shape=(4,) val="0x200001"
 	@description: type=str val="Angle (deg)"
@@ -18483,8 +19070,6 @@ Generating signature for 170714_22_26_27.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0087_red/pixel_mask_index: dtype=int64 shape=(4,) val="0xc0000b"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0087_red/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0087_red/pixel_time_offsets: dtype=float64 shape=(4, 1) val="0xe79e0e84"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0087_red/reference_images/Zstack_Red_0087 -> /acquisition/Zstack_Red_0087
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0087_red/reference_images/reference_images -> /acquisition/Zstack_Red_0087
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0087_red/roi_group_id: dtype=float64 shape=(4,) val="0x200001"
@@ -18508,7 +19093,7 @@ Generating signature for 170714_22_26_27.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0087_red/zoom: dtype=float64 shape=(4,) val="0x416c04bd"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0097_green
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0097_green/angle_deg: dtype=float64 shape=(10,) val="0x500001"
 	@description: type=str val="Angle (deg)"
@@ -18530,8 +19115,6 @@ Generating signature for 170714_22_26_27.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0097_green/pixel_mask_index: dtype=int64 shape=(10,) val="0x7300038"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0097_green/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0097_green/pixel_time_offsets: dtype=float64 shape=(10, 1) val="0x84462ad4"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0097_green/reference_images/Zstack_Red_0097 -> /acquisition/Zstack_Red_0097
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0097_green/reference_images/reference_images -> /acquisition/Zstack_Red_0097
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0097_green/roi_group_id: dtype=float64 shape=(10,) val="0x500001"
@@ -18555,7 +19138,7 @@ Generating signature for 170714_22_26_27.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0097_green/zoom: dtype=float64 shape=(10,) val="0xbfad0bd7"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0097_red
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0097_red/angle_deg: dtype=float64 shape=(10,) val="0x500001"
 	@description: type=str val="Angle (deg)"
@@ -18577,8 +19160,6 @@ Generating signature for 170714_22_26_27.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0097_red/pixel_mask_index: dtype=int64 shape=(10,) val="0x7300038"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0097_red/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0097_red/pixel_time_offsets: dtype=float64 shape=(10, 1) val="0x84462ad4"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0097_red/reference_images/Zstack_Red_0097 -> /acquisition/Zstack_Red_0097
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0097_red/reference_images/reference_images -> /acquisition/Zstack_Red_0097
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0097_red/roi_group_id: dtype=float64 shape=(10,) val="0x500001"
@@ -18602,7 +19183,7 @@ Generating signature for 170714_22_26_27.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0097_red/zoom: dtype=float64 shape=(10,) val="0xbfad0bd7"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0103_green
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0103_green/angle_deg: dtype=float64 shape=(10,) val="0x500001"
 	@description: type=str val="Angle (deg)"
@@ -18624,8 +19205,6 @@ Generating signature for 170714_22_26_27.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0103_green/pixel_mask_index: dtype=int64 shape=(10,) val="0x7300038"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0103_green/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0103_green/pixel_time_offsets: dtype=float64 shape=(10, 1) val="0x14a824a7"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0103_green/reference_images/Zstack_Red_0103 -> /acquisition/Zstack_Red_0103
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0103_green/reference_images/reference_images -> /acquisition/Zstack_Red_0103
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0103_green/roi_group_id: dtype=float64 shape=(10,) val="0x500001"
@@ -18649,7 +19228,7 @@ Generating signature for 170714_22_26_27.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0103_green/zoom: dtype=float64 shape=(10,) val="0xbfad0bd7"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0103_red
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0103_red/angle_deg: dtype=float64 shape=(10,) val="0x500001"
 	@description: type=str val="Angle (deg)"
@@ -18671,8 +19250,6 @@ Generating signature for 170714_22_26_27.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0103_red/pixel_mask_index: dtype=int64 shape=(10,) val="0x7300038"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0103_red/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0103_red/pixel_time_offsets: dtype=float64 shape=(10, 1) val="0x14a824a7"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0103_red/reference_images/Zstack_Red_0103 -> /acquisition/Zstack_Red_0103
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0103_red/reference_images/reference_images -> /acquisition/Zstack_Red_0103
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0103_red/roi_group_id: dtype=float64 shape=(10,) val="0x500001"
@@ -18696,7 +19273,7 @@ Generating signature for 170714_22_26_27.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0103_red/zoom: dtype=float64 shape=(10,) val="0xbfad0bd7"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0110_green
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0110_green/angle_deg: dtype=float64 shape=(11,) val="0x580001"
 	@description: type=str val="Angle (deg)"
@@ -18718,8 +19295,6 @@ Generating signature for 170714_22_26_27.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0110_green/pixel_mask_index: dtype=int64 shape=(11,) val="0x9480043"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0110_green/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0110_green/pixel_time_offsets: dtype=float64 shape=(11, 1) val="0x63152a7f"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0110_green/reference_images/Zstack_Red_0110 -> /acquisition/Zstack_Red_0110
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0110_green/reference_images/reference_images -> /acquisition/Zstack_Red_0110
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0110_green/roi_group_id: dtype=float64 shape=(11,) val="0x580001"
@@ -18743,7 +19318,7 @@ Generating signature for 170714_22_26_27.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0110_green/zoom: dtype=float64 shape=(11,) val="0x20930d06"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0110_red
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0110_red/angle_deg: dtype=float64 shape=(11,) val="0x580001"
 	@description: type=str val="Angle (deg)"
@@ -18765,8 +19340,6 @@ Generating signature for 170714_22_26_27.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0110_red/pixel_mask_index: dtype=int64 shape=(11,) val="0x9480043"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0110_red/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0110_red/pixel_time_offsets: dtype=float64 shape=(11, 1) val="0x63152a7f"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0110_red/reference_images/Zstack_Red_0110 -> /acquisition/Zstack_Red_0110
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0110_red/reference_images/reference_images -> /acquisition/Zstack_Red_0110
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0110_red/roi_group_id: dtype=float64 shape=(11,) val="0x580001"
@@ -18790,7 +19363,7 @@ Generating signature for 170714_22_26_27.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0110_red/zoom: dtype=float64 shape=(11,) val="0x20930d06"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0111_green
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0111_green/angle_deg: dtype=float64 shape=(6,) val="0x300001"
 	@description: type=str val="Angle (deg)"
@@ -18812,8 +19385,6 @@ Generating signature for 170714_22_26_27.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0111_green/pixel_mask_index: dtype=int64 shape=(6,) val="0x1f00016"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0111_green/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0111_green/pixel_time_offsets: dtype=float64 shape=(6, 1) val="0xfe6e14e2"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0111_green/reference_images/Zstack_Red_0111 -> /acquisition/Zstack_Red_0111
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0111_green/reference_images/reference_images -> /acquisition/Zstack_Red_0111
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0111_green/roi_group_id: dtype=float64 shape=(6,) val="0x300001"
@@ -18837,7 +19408,7 @@ Generating signature for 170714_22_26_27.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0111_green/zoom: dtype=float64 shape=(6,) val="0x9af2071b"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0111_red
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0111_red/angle_deg: dtype=float64 shape=(6,) val="0x300001"
 	@description: type=str val="Angle (deg)"
@@ -18859,8 +19430,6 @@ Generating signature for 170714_22_26_27.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0111_red/pixel_mask_index: dtype=int64 shape=(6,) val="0x1f00016"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0111_red/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0111_red/pixel_time_offsets: dtype=float64 shape=(6, 1) val="0xfe6e14e2"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0111_red/reference_images/Zstack_Red_0111 -> /acquisition/Zstack_Red_0111
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0111_red/reference_images/reference_images -> /acquisition/Zstack_Red_0111
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0111_red/roi_group_id: dtype=float64 shape=(6,) val="0x300001"
@@ -18884,7 +19453,7 @@ Generating signature for 170714_22_26_27.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0111_red/zoom: dtype=float64 shape=(6,) val="0x9af2071b"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0120_green
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0120_green/angle_deg: dtype=float64 shape=(2,) val="0x100001"
 	@description: type=str val="Angle (deg)"
@@ -18906,8 +19475,6 @@ Generating signature for 170714_22_26_27.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0120_green/pixel_mask_index: dtype=int64 shape=(2,) val="0x300004"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0120_green/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0120_green/pixel_time_offsets: dtype=float64 shape=(2, 1) val="0x518808cf"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0120_green/reference_images/Zstack_Red_0120 -> /acquisition/Zstack_Red_0120
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0120_green/reference_images/reference_images -> /acquisition/Zstack_Red_0120
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0120_green/roi_group_id: dtype=float64 shape=(2,) val="0x100001"
@@ -18931,7 +19498,7 @@ Generating signature for 170714_22_26_27.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0120_green/zoom: dtype=float64 shape=(2,) val="0xdc6025f"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0120_red
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0120_red/angle_deg: dtype=float64 shape=(2,) val="0x100001"
 	@description: type=str val="Angle (deg)"
@@ -18953,8 +19520,6 @@ Generating signature for 170714_22_26_27.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0120_red/pixel_mask_index: dtype=int64 shape=(2,) val="0x300004"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0120_red/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0120_red/pixel_time_offsets: dtype=float64 shape=(2, 1) val="0x518808cf"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0120_red/reference_images/Zstack_Red_0120 -> /acquisition/Zstack_Red_0120
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0120_red/reference_images/reference_images -> /acquisition/Zstack_Red_0120
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0120_red/roi_group_id: dtype=float64 shape=(2,) val="0x100001"
@@ -18978,7 +19543,7 @@ Generating signature for 170714_22_26_27.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0120_red/zoom: dtype=float64 shape=(2,) val="0xdc6025f"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0122_green
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0122_green/angle_deg: dtype=float64 shape=(13,) val="0x680001"
 	@description: type=str val="Angle (deg)"
@@ -19000,8 +19565,6 @@ Generating signature for 170714_22_26_27.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0122_green/pixel_mask_index: dtype=int64 shape=(13,) val="0xea0005c"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0122_green/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0122_green/pixel_time_offsets: dtype=float64 shape=(13, 1) val="0x324e31d2"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0122_green/reference_images/Zstack_Red_0122 -> /acquisition/Zstack_Red_0122
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0122_green/reference_images/reference_images -> /acquisition/Zstack_Red_0122
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0122_green/roi_group_id: dtype=float64 shape=(13,) val="0x680001"
@@ -19025,7 +19588,7 @@ Generating signature for 170714_22_26_27.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0122_green/zoom: dtype=float64 shape=(13,) val="0xfea90f64"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0122_red
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0122_red/angle_deg: dtype=float64 shape=(13,) val="0x680001"
 	@description: type=str val="Angle (deg)"
@@ -19047,8 +19610,6 @@ Generating signature for 170714_22_26_27.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0122_red/pixel_mask_index: dtype=int64 shape=(13,) val="0xea0005c"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0122_red/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0122_red/pixel_time_offsets: dtype=float64 shape=(13, 1) val="0x324e31d2"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0122_red/reference_images/Zstack_Red_0122 -> /acquisition/Zstack_Red_0122
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0122_red/reference_images/reference_images -> /acquisition/Zstack_Red_0122
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0122_red/roi_group_id: dtype=float64 shape=(13,) val="0x680001"
@@ -19072,7 +19633,7 @@ Generating signature for 170714_22_26_27.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0122_red/zoom: dtype=float64 shape=(13,) val="0xfea90f64"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0126_green
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0126_green/angle_deg: dtype=float64 shape=(5,) val="0x280001"
 	@description: type=str val="Angle (deg)"
@@ -19094,8 +19655,6 @@ Generating signature for 170714_22_26_27.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0126_green/pixel_mask_index: dtype=int64 shape=(5,) val="0x1400010"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0126_green/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0126_green/pixel_time_offsets: dtype=float64 shape=(5, 1) val="0xb9c71555"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0126_green/reference_images/Zstack_Red_0126 -> /acquisition/Zstack_Red_0126
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0126_green/reference_images/reference_images -> /acquisition/Zstack_Red_0126
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0126_green/roi_group_id: dtype=float64 shape=(5,) val="0x280001"
@@ -19119,7 +19678,7 @@ Generating signature for 170714_22_26_27.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0126_green/zoom: dtype=float64 shape=(5,) val="0x697305ec"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0126_red
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0126_red/angle_deg: dtype=float64 shape=(5,) val="0x280001"
 	@description: type=str val="Angle (deg)"
@@ -19141,8 +19700,6 @@ Generating signature for 170714_22_26_27.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0126_red/pixel_mask_index: dtype=int64 shape=(5,) val="0x1400010"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0126_red/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0126_red/pixel_time_offsets: dtype=float64 shape=(5, 1) val="0xb9c71555"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0126_red/reference_images/Zstack_Red_0126 -> /acquisition/Zstack_Red_0126
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0126_red/reference_images/reference_images -> /acquisition/Zstack_Red_0126
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0126_red/roi_group_id: dtype=float64 shape=(5,) val="0x280001"
@@ -19166,7 +19723,7 @@ Generating signature for 170714_22_26_27.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0126_red/zoom: dtype=float64 shape=(5,) val="0x697305ec"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0127_green
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0127_green/angle_deg: dtype=float64 shape=(3,) val="0x180001"
 	@description: type=str val="Angle (deg)"
@@ -19188,8 +19745,6 @@ Generating signature for 170714_22_26_27.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0127_green/pixel_mask_index: dtype=int64 shape=(3,) val="0x680007"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0127_green/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0127_green/pixel_time_offsets: dtype=float64 shape=(3, 1) val="0x77ed09b5"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0127_green/reference_images/Zstack_Red_0127 -> /acquisition/Zstack_Red_0127
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0127_green/reference_images/reference_images -> /acquisition/Zstack_Red_0127
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0127_green/roi_group_id: dtype=float64 shape=(3,) val="0x180001"
@@ -19213,7 +19768,7 @@ Generating signature for 170714_22_26_27.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0127_green/zoom: dtype=float64 shape=(3,) val="0x22dd038e"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0127_red
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0127_red/angle_deg: dtype=float64 shape=(3,) val="0x180001"
 	@description: type=str val="Angle (deg)"
@@ -19235,8 +19790,6 @@ Generating signature for 170714_22_26_27.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0127_red/pixel_mask_index: dtype=int64 shape=(3,) val="0x680007"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0127_red/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0127_red/pixel_time_offsets: dtype=float64 shape=(3, 1) val="0x77ed09b5"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0127_red/reference_images/Zstack_Red_0127 -> /acquisition/Zstack_Red_0127
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0127_red/reference_images/reference_images -> /acquisition/Zstack_Red_0127
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0127_red/roi_group_id: dtype=float64 shape=(3,) val="0x180001"
@@ -19260,7 +19813,7 @@ Generating signature for 170714_22_26_27.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0127_red/zoom: dtype=float64 shape=(3,) val="0x22dd038e"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0129_green
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0129_green/angle_deg: dtype=float64 shape=(6,) val="0x300001"
 	@description: type=str val="Angle (deg)"
@@ -19282,8 +19835,6 @@ Generating signature for 170714_22_26_27.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0129_green/pixel_mask_index: dtype=int64 shape=(6,) val="0x1f00016"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0129_green/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0129_green/pixel_time_offsets: dtype=float64 shape=(6, 1) val="0x6dd1537"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0129_green/reference_images/Zstack_Red_0129 -> /acquisition/Zstack_Red_0129
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0129_green/reference_images/reference_images -> /acquisition/Zstack_Red_0129
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0129_green/roi_group_id: dtype=float64 shape=(6,) val="0x300001"
@@ -19307,7 +19858,7 @@ Generating signature for 170714_22_26_27.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0129_green/zoom: dtype=float64 shape=(6,) val="0x9af2071b"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0129_red
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0129_red/angle_deg: dtype=float64 shape=(6,) val="0x300001"
 	@description: type=str val="Angle (deg)"
@@ -19329,8 +19880,6 @@ Generating signature for 170714_22_26_27.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0129_red/pixel_mask_index: dtype=int64 shape=(6,) val="0x1f00016"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0129_red/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0129_red/pixel_time_offsets: dtype=float64 shape=(6, 1) val="0x6dd1537"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0129_red/reference_images/Zstack_Red_0129 -> /acquisition/Zstack_Red_0129
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0129_red/reference_images/reference_images -> /acquisition/Zstack_Red_0129
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0129_red/roi_group_id: dtype=float64 shape=(6,) val="0x300001"
@@ -19354,7 +19903,7 @@ Generating signature for 170714_22_26_27.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0129_red/zoom: dtype=float64 shape=(6,) val="0x9af2071b"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0130_green
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0130_green/angle_deg: dtype=float64 shape=(5,) val="0x280001"
 	@description: type=str val="Angle (deg)"
@@ -19376,8 +19925,6 @@ Generating signature for 170714_22_26_27.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0130_green/pixel_mask_index: dtype=int64 shape=(5,) val="0x1400010"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0130_green/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0130_green/pixel_time_offsets: dtype=float64 shape=(5, 1) val="0x81d812b0"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0130_green/reference_images/Zstack_Red_0130 -> /acquisition/Zstack_Red_0130
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0130_green/reference_images/reference_images -> /acquisition/Zstack_Red_0130
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0130_green/roi_group_id: dtype=float64 shape=(5,) val="0x280001"
@@ -19401,7 +19948,7 @@ Generating signature for 170714_22_26_27.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0130_green/zoom: dtype=float64 shape=(5,) val="0x697305ec"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0130_red
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0130_red/angle_deg: dtype=float64 shape=(5,) val="0x280001"
 	@description: type=str val="Angle (deg)"
@@ -19423,8 +19970,6 @@ Generating signature for 170714_22_26_27.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0130_red/pixel_mask_index: dtype=int64 shape=(5,) val="0x1400010"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0130_red/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0130_red/pixel_time_offsets: dtype=float64 shape=(5, 1) val="0x81d812b0"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0130_red/reference_images/Zstack_Red_0130 -> /acquisition/Zstack_Red_0130
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0130_red/reference_images/reference_images -> /acquisition/Zstack_Red_0130
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0130_red/roi_group_id: dtype=float64 shape=(5,) val="0x280001"
@@ -19448,7 +19993,7 @@ Generating signature for 170714_22_26_27.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0130_red/zoom: dtype=float64 shape=(5,) val="0x697305ec"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0131_green
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0131_green/angle_deg: dtype=float64 shape=(7,) val="0x380001"
 	@description: type=str val="Angle (deg)"
@@ -19470,8 +20015,6 @@ Generating signature for 170714_22_26_27.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0131_green/pixel_mask_index: dtype=int64 shape=(7,) val="0x2d8001d"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0131_green/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0131_green/pixel_time_offsets: dtype=float64 shape=(7, 1) val="0x21f91abc"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0131_green/reference_images/Zstack_Red_0131 -> /acquisition/Zstack_Red_0131
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0131_green/reference_images/reference_images -> /acquisition/Zstack_Red_0131
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0131_green/roi_group_id: dtype=float64 shape=(7,) val="0x380001"
@@ -19495,7 +20038,7 @@ Generating signature for 170714_22_26_27.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0131_green/zoom: dtype=float64 shape=(7,) val="0xd5e9084a"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0131_red
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0131_red/angle_deg: dtype=float64 shape=(7,) val="0x380001"
 	@description: type=str val="Angle (deg)"
@@ -19517,8 +20060,6 @@ Generating signature for 170714_22_26_27.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0131_red/pixel_mask_index: dtype=int64 shape=(7,) val="0x2d8001d"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0131_red/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0131_red/pixel_time_offsets: dtype=float64 shape=(7, 1) val="0x21f91abc"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0131_red/reference_images/Zstack_Red_0131 -> /acquisition/Zstack_Red_0131
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0131_red/reference_images/reference_images -> /acquisition/Zstack_Red_0131
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0131_red/roi_group_id: dtype=float64 shape=(7,) val="0x380001"
@@ -19542,7 +20083,7 @@ Generating signature for 170714_22_26_27.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0131_red/zoom: dtype=float64 shape=(7,) val="0xd5e9084a"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0132_green
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0132_green/angle_deg: dtype=float64 shape=(14,) val="0x700001"
 	@description: type=str val="Angle (deg)"
@@ -19564,8 +20105,6 @@ Generating signature for 170714_22_26_27.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0132_green/pixel_mask_index: dtype=int64 shape=(14,) val="0x11f0006a"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0132_green/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0132_green/pixel_time_offsets: dtype=float64 shape=(14, 1) val="0x88e734e6"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0132_green/reference_images/Zstack_Red_0132 -> /acquisition/Zstack_Red_0132
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0132_green/reference_images/reference_images -> /acquisition/Zstack_Red_0132
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0132_green/roi_group_id: dtype=float64 shape=(14,) val="0x700001"
@@ -19589,7 +20128,7 @@ Generating signature for 170714_22_26_27.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0132_green/zoom: dtype=float64 shape=(14,) val="0x7bf71093"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0132_red
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0132_red/angle_deg: dtype=float64 shape=(14,) val="0x700001"
 	@description: type=str val="Angle (deg)"
@@ -19611,8 +20150,6 @@ Generating signature for 170714_22_26_27.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0132_red/pixel_mask_index: dtype=int64 shape=(14,) val="0x11f0006a"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0132_red/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0132_red/pixel_time_offsets: dtype=float64 shape=(14, 1) val="0x88e734e6"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0132_red/reference_images/Zstack_Red_0132 -> /acquisition/Zstack_Red_0132
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0132_red/reference_images/reference_images -> /acquisition/Zstack_Red_0132
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0132_red/roi_group_id: dtype=float64 shape=(14,) val="0x700001"
@@ -19636,7 +20173,7 @@ Generating signature for 170714_22_26_27.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0132_red/zoom: dtype=float64 shape=(14,) val="0x7bf71093"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0133_green
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0133_green/angle_deg: dtype=float64 shape=(8,) val="0x400001"
 	@description: type=str val="Angle (deg)"
@@ -19658,8 +20195,6 @@ Generating signature for 170714_22_26_27.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0133_green/pixel_mask_index: dtype=int64 shape=(8,) val="0x4000025"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0133_green/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0133_green/pixel_time_offsets: dtype=float64 shape=(8, 1) val="0x61ed1b4e"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0133_green/reference_images/Zstack_Red_0133 -> /acquisition/Zstack_Red_0133
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0133_green/reference_images/reference_images -> /acquisition/Zstack_Red_0133
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0133_green/roi_group_id: dtype=float64 shape=(8,) val="0x400001"
@@ -19683,7 +20218,7 @@ Generating signature for 170714_22_26_27.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0133_green/zoom: dtype=float64 shape=(8,) val="0x1a670979"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0133_red
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0133_red/angle_deg: dtype=float64 shape=(8,) val="0x400001"
 	@description: type=str val="Angle (deg)"
@@ -19705,8 +20240,6 @@ Generating signature for 170714_22_26_27.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0133_red/pixel_mask_index: dtype=int64 shape=(8,) val="0x4000025"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0133_red/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0133_red/pixel_time_offsets: dtype=float64 shape=(8, 1) val="0x61ed1b4e"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0133_red/reference_images/Zstack_Red_0133 -> /acquisition/Zstack_Red_0133
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0133_red/reference_images/reference_images -> /acquisition/Zstack_Red_0133
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0133_red/roi_group_id: dtype=float64 shape=(8,) val="0x400001"
@@ -19730,7 +20263,7 @@ Generating signature for 170714_22_26_27.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0133_red/zoom: dtype=float64 shape=(8,) val="0x1a670979"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0134_green
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0134_green/angle_deg: dtype=float64 shape=(9,) val="0x480001"
 	@description: type=str val="Angle (deg)"
@@ -19752,8 +20285,6 @@ Generating signature for 170714_22_26_27.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0134_green/pixel_mask_index: dtype=int64 shape=(9,) val="0x570002e"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0134_green/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0134_green/pixel_time_offsets: dtype=float64 shape=(9, 1) val="0x99f1200d"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0134_green/reference_images/Zstack_Red_0134 -> /acquisition/Zstack_Red_0134
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0134_green/reference_images/reference_images -> /acquisition/Zstack_Red_0134
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0134_green/roi_group_id: dtype=float64 shape=(9,) val="0x480001"
@@ -19777,7 +20308,7 @@ Generating signature for 170714_22_26_27.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0134_green/zoom: dtype=float64 shape=(9,) val="0x684e0aa8"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0134_red
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0134_red/angle_deg: dtype=float64 shape=(9,) val="0x480001"
 	@description: type=str val="Angle (deg)"
@@ -19799,8 +20330,6 @@ Generating signature for 170714_22_26_27.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0134_red/pixel_mask_index: dtype=int64 shape=(9,) val="0x570002e"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0134_red/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0134_red/pixel_time_offsets: dtype=float64 shape=(9, 1) val="0x99f1200d"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0134_red/reference_images/Zstack_Red_0134 -> /acquisition/Zstack_Red_0134
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0134_red/reference_images/reference_images -> /acquisition/Zstack_Red_0134
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0134_red/roi_group_id: dtype=float64 shape=(9,) val="0x480001"
@@ -19824,7 +20353,7 @@ Generating signature for 170714_22_26_27.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0134_red/zoom: dtype=float64 shape=(9,) val="0x684e0aa8"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0135_green
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0135_green/angle_deg: dtype=float64 shape=(6,) val="0x300001"
 	@description: type=str val="Angle (deg)"
@@ -19846,8 +20375,6 @@ Generating signature for 170714_22_26_27.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0135_green/pixel_mask_index: dtype=int64 shape=(6,) val="0x1f00016"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0135_green/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0135_green/pixel_time_offsets: dtype=float64 shape=(6, 1) val="0xd9291434"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0135_green/reference_images/Zstack_Red_0135 -> /acquisition/Zstack_Red_0135
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0135_green/reference_images/reference_images -> /acquisition/Zstack_Red_0135
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0135_green/roi_group_id: dtype=float64 shape=(6,) val="0x300001"
@@ -19871,7 +20398,7 @@ Generating signature for 170714_22_26_27.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0135_green/zoom: dtype=float64 shape=(6,) val="0x9af2071b"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0135_red
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0135_red/angle_deg: dtype=float64 shape=(6,) val="0x300001"
 	@description: type=str val="Angle (deg)"
@@ -19893,8 +20420,6 @@ Generating signature for 170714_22_26_27.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0135_red/pixel_mask_index: dtype=int64 shape=(6,) val="0x1f00016"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0135_red/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0135_red/pixel_time_offsets: dtype=float64 shape=(6, 1) val="0xd9291434"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0135_red/reference_images/Zstack_Red_0135 -> /acquisition/Zstack_Red_0135
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0135_red/reference_images/reference_images -> /acquisition/Zstack_Red_0135
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0135_red/roi_group_id: dtype=float64 shape=(6,) val="0x300001"
@@ -19918,7 +20443,7 @@ Generating signature for 170714_22_26_27.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0135_red/zoom: dtype=float64 shape=(6,) val="0x9af2071b"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0136_green
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0136_green/angle_deg: dtype=float64 shape=(8,) val="0x400001"
 	@description: type=str val="Angle (deg)"
@@ -19940,8 +20465,6 @@ Generating signature for 170714_22_26_27.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0136_green/pixel_mask_index: dtype=int64 shape=(8,) val="0x4000025"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0136_green/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0136_green/pixel_time_offsets: dtype=float64 shape=(8, 1) val="0x10f1e43"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0136_green/reference_images/Zstack_Red_0136 -> /acquisition/Zstack_Red_0136
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0136_green/reference_images/reference_images -> /acquisition/Zstack_Red_0136
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0136_green/roi_group_id: dtype=float64 shape=(8,) val="0x400001"
@@ -19965,7 +20488,7 @@ Generating signature for 170714_22_26_27.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0136_green/zoom: dtype=float64 shape=(8,) val="0x1a670979"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0136_red
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0136_red/angle_deg: dtype=float64 shape=(8,) val="0x400001"
 	@description: type=str val="Angle (deg)"
@@ -19987,8 +20510,6 @@ Generating signature for 170714_22_26_27.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0136_red/pixel_mask_index: dtype=int64 shape=(8,) val="0x4000025"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0136_red/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0136_red/pixel_time_offsets: dtype=float64 shape=(8, 1) val="0x10f1e43"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0136_red/reference_images/Zstack_Red_0136 -> /acquisition/Zstack_Red_0136
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0136_red/reference_images/reference_images -> /acquisition/Zstack_Red_0136
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0136_red/roi_group_id: dtype=float64 shape=(8,) val="0x400001"
@@ -20012,7 +20533,7 @@ Generating signature for 170714_22_26_27.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0136_red/zoom: dtype=float64 shape=(8,) val="0x1a670979"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0137_green
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0137_green/angle_deg: dtype=float64 shape=(8,) val="0x400001"
 	@description: type=str val="Angle (deg)"
@@ -20034,8 +20555,6 @@ Generating signature for 170714_22_26_27.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0137_green/pixel_mask_index: dtype=int64 shape=(8,) val="0x4000025"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0137_green/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0137_green/pixel_time_offsets: dtype=float64 shape=(8, 1) val="0xb5581ea9"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0137_green/reference_images/Zstack_Red_0137 -> /acquisition/Zstack_Red_0137
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0137_green/reference_images/reference_images -> /acquisition/Zstack_Red_0137
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0137_green/roi_group_id: dtype=float64 shape=(8,) val="0x400001"
@@ -20059,7 +20578,7 @@ Generating signature for 170714_22_26_27.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0137_green/zoom: dtype=float64 shape=(8,) val="0x1a670979"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0137_red
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0137_red/angle_deg: dtype=float64 shape=(8,) val="0x400001"
 	@description: type=str val="Angle (deg)"
@@ -20081,8 +20600,6 @@ Generating signature for 170714_22_26_27.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0137_red/pixel_mask_index: dtype=int64 shape=(8,) val="0x4000025"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0137_red/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0137_red/pixel_time_offsets: dtype=float64 shape=(8, 1) val="0xb5581ea9"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0137_red/reference_images/Zstack_Red_0137 -> /acquisition/Zstack_Red_0137
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0137_red/reference_images/reference_images -> /acquisition/Zstack_Red_0137
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0137_red/roi_group_id: dtype=float64 shape=(8,) val="0x400001"
@@ -20106,7 +20623,7 @@ Generating signature for 170714_22_26_27.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0137_red/zoom: dtype=float64 shape=(8,) val="0x1a670979"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0138_green
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0138_green/angle_deg: dtype=float64 shape=(4,) val="0x200001"
 	@description: type=str val="Angle (deg)"
@@ -20128,8 +20645,6 @@ Generating signature for 170714_22_26_27.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0138_green/pixel_mask_index: dtype=int64 shape=(4,) val="0xc0000b"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0138_green/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0138_green/pixel_time_offsets: dtype=float64 shape=(4, 1) val="0xecb20e3f"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0138_green/reference_images/Zstack_Red_0138 -> /acquisition/Zstack_Red_0138
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0138_green/reference_images/reference_images -> /acquisition/Zstack_Red_0138
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0138_green/roi_group_id: dtype=float64 shape=(4,) val="0x200001"
@@ -20153,7 +20668,7 @@ Generating signature for 170714_22_26_27.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0138_green/zoom: dtype=float64 shape=(4,) val="0x416c04bd"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0138_red
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0138_red/angle_deg: dtype=float64 shape=(4,) val="0x200001"
 	@description: type=str val="Angle (deg)"
@@ -20175,8 +20690,6 @@ Generating signature for 170714_22_26_27.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0138_red/pixel_mask_index: dtype=int64 shape=(4,) val="0xc0000b"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0138_red/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0138_red/pixel_time_offsets: dtype=float64 shape=(4, 1) val="0xecb20e3f"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0138_red/reference_images/Zstack_Red_0138 -> /acquisition/Zstack_Red_0138
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0138_red/reference_images/reference_images -> /acquisition/Zstack_Red_0138
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0138_red/roi_group_id: dtype=float64 shape=(4,) val="0x200001"
@@ -20200,7 +20713,7 @@ Generating signature for 170714_22_26_27.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0138_red/zoom: dtype=float64 shape=(4,) val="0x416c04bd"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0139_green
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0139_green/angle_deg: dtype=float64 shape=(10,) val="0x500001"
 	@description: type=str val="Angle (deg)"
@@ -20222,8 +20735,6 @@ Generating signature for 170714_22_26_27.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0139_green/pixel_mask_index: dtype=int64 shape=(10,) val="0x7300038"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0139_green/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0139_green/pixel_time_offsets: dtype=float64 shape=(10, 1) val="0xcac1f78"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0139_green/reference_images/Zstack_Red_0139 -> /acquisition/Zstack_Red_0139
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0139_green/reference_images/reference_images -> /acquisition/Zstack_Red_0139
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0139_green/roi_group_id: dtype=float64 shape=(10,) val="0x500001"
@@ -20247,7 +20758,7 @@ Generating signature for 170714_22_26_27.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0139_green/zoom: dtype=float64 shape=(10,) val="0xbfad0bd7"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0139_red
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0139_red/angle_deg: dtype=float64 shape=(10,) val="0x500001"
 	@description: type=str val="Angle (deg)"
@@ -20269,8 +20780,6 @@ Generating signature for 170714_22_26_27.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0139_red/pixel_mask_index: dtype=int64 shape=(10,) val="0x7300038"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0139_red/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0139_red/pixel_time_offsets: dtype=float64 shape=(10, 1) val="0xcac1f78"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0139_red/reference_images/Zstack_Red_0139 -> /acquisition/Zstack_Red_0139
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0139_red/reference_images/reference_images -> /acquisition/Zstack_Red_0139
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0139_red/roi_group_id: dtype=float64 shape=(10,) val="0x500001"
@@ -20294,7 +20803,7 @@ Generating signature for 170714_22_26_27.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0139_red/zoom: dtype=float64 shape=(10,) val="0xbfad0bd7"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0140_green
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0140_green/angle_deg: dtype=float64 shape=(7,) val="0x380001"
 	@description: type=str val="Angle (deg)"
@@ -20316,8 +20825,6 @@ Generating signature for 170714_22_26_27.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0140_green/pixel_mask_index: dtype=int64 shape=(7,) val="0x2d8001d"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0140_green/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0140_green/pixel_time_offsets: dtype=float64 shape=(7, 1) val="0xc4311769"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0140_green/reference_images/Zstack_Red_0140 -> /acquisition/Zstack_Red_0140
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0140_green/reference_images/reference_images -> /acquisition/Zstack_Red_0140
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0140_green/roi_group_id: dtype=float64 shape=(7,) val="0x380001"
@@ -20341,7 +20848,7 @@ Generating signature for 170714_22_26_27.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0140_green/zoom: dtype=float64 shape=(7,) val="0xd5e9084a"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0140_red
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0140_red/angle_deg: dtype=float64 shape=(7,) val="0x380001"
 	@description: type=str val="Angle (deg)"
@@ -20363,8 +20870,6 @@ Generating signature for 170714_22_26_27.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0140_red/pixel_mask_index: dtype=int64 shape=(7,) val="0x2d8001d"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0140_red/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0140_red/pixel_time_offsets: dtype=float64 shape=(7, 1) val="0xc4311769"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0140_red/reference_images/Zstack_Red_0140 -> /acquisition/Zstack_Red_0140
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0140_red/reference_images/reference_images -> /acquisition/Zstack_Red_0140
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0140_red/roi_group_id: dtype=float64 shape=(7,) val="0x380001"
@@ -20388,7 +20893,7 @@ Generating signature for 170714_22_26_27.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0140_red/zoom: dtype=float64 shape=(7,) val="0xd5e9084a"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0141_green
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0141_green/angle_deg: dtype=float64 shape=(9,) val="0x480001"
 	@description: type=str val="Angle (deg)"
@@ -20410,8 +20915,6 @@ Generating signature for 170714_22_26_27.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0141_green/pixel_mask_index: dtype=int64 shape=(9,) val="0x570002e"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0141_green/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0141_green/pixel_time_offsets: dtype=float64 shape=(9, 1) val="0x21ed1be8"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0141_green/reference_images/Zstack_Red_0141 -> /acquisition/Zstack_Red_0141
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0141_green/reference_images/reference_images -> /acquisition/Zstack_Red_0141
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0141_green/roi_group_id: dtype=float64 shape=(9,) val="0x480001"
@@ -20435,7 +20938,7 @@ Generating signature for 170714_22_26_27.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0141_green/zoom: dtype=float64 shape=(9,) val="0x684e0aa8"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0141_red
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0141_red/angle_deg: dtype=float64 shape=(9,) val="0x480001"
 	@description: type=str val="Angle (deg)"
@@ -20457,8 +20960,6 @@ Generating signature for 170714_22_26_27.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0141_red/pixel_mask_index: dtype=int64 shape=(9,) val="0x570002e"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0141_red/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0141_red/pixel_time_offsets: dtype=float64 shape=(9, 1) val="0x21ed1be8"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0141_red/reference_images/Zstack_Red_0141 -> /acquisition/Zstack_Red_0141
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0141_red/reference_images/reference_images -> /acquisition/Zstack_Red_0141
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0141_red/roi_group_id: dtype=float64 shape=(9,) val="0x480001"
@@ -20482,7 +20983,7 @@ Generating signature for 170714_22_26_27.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0141_red/zoom: dtype=float64 shape=(9,) val="0x684e0aa8"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0142_green
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0142_green/angle_deg: dtype=float64 shape=(5,) val="0x280001"
 	@description: type=str val="Angle (deg)"
@@ -20504,8 +21005,6 @@ Generating signature for 170714_22_26_27.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0142_green/pixel_mask_index: dtype=int64 shape=(5,) val="0x1400010"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0142_green/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0142_green/pixel_time_offsets: dtype=float64 shape=(5, 1) val="0x92f41378"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0142_green/reference_images/Zstack_Red_0142 -> /acquisition/Zstack_Red_0142
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0142_green/reference_images/reference_images -> /acquisition/Zstack_Red_0142
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0142_green/roi_group_id: dtype=float64 shape=(5,) val="0x280001"
@@ -20529,7 +21028,7 @@ Generating signature for 170714_22_26_27.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0142_green/zoom: dtype=float64 shape=(5,) val="0x697305ec"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0142_red
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0142_red/angle_deg: dtype=float64 shape=(5,) val="0x280001"
 	@description: type=str val="Angle (deg)"
@@ -20551,8 +21050,6 @@ Generating signature for 170714_22_26_27.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0142_red/pixel_mask_index: dtype=int64 shape=(5,) val="0x1400010"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0142_red/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0142_red/pixel_time_offsets: dtype=float64 shape=(5, 1) val="0x92f41378"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0142_red/reference_images/Zstack_Red_0142 -> /acquisition/Zstack_Red_0142
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0142_red/reference_images/reference_images -> /acquisition/Zstack_Red_0142
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0142_red/roi_group_id: dtype=float64 shape=(5,) val="0x280001"
@@ -20576,7 +21073,7 @@ Generating signature for 170714_22_26_27.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0142_red/zoom: dtype=float64 shape=(5,) val="0x697305ec"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0143_green
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0143_green/angle_deg: dtype=float64 shape=(5,) val="0x280001"
 	@description: type=str val="Angle (deg)"
@@ -20598,8 +21095,6 @@ Generating signature for 170714_22_26_27.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0143_green/pixel_mask_index: dtype=int64 shape=(5,) val="0x1400010"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0143_green/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0143_green/pixel_time_offsets: dtype=float64 shape=(5, 1) val="0xf9880ded"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0143_green/reference_images/Zstack_Red_0143 -> /acquisition/Zstack_Red_0143
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0143_green/reference_images/reference_images -> /acquisition/Zstack_Red_0143
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0143_green/roi_group_id: dtype=float64 shape=(5,) val="0x280001"
@@ -20623,7 +21118,7 @@ Generating signature for 170714_22_26_27.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0143_green/zoom: dtype=float64 shape=(5,) val="0x697305ec"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0143_red
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0143_red/angle_deg: dtype=float64 shape=(5,) val="0x280001"
 	@description: type=str val="Angle (deg)"
@@ -20645,8 +21140,6 @@ Generating signature for 170714_22_26_27.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0143_red/pixel_mask_index: dtype=int64 shape=(5,) val="0x1400010"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0143_red/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0143_red/pixel_time_offsets: dtype=float64 shape=(5, 1) val="0xf9880ded"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0143_red/reference_images/Zstack_Red_0143 -> /acquisition/Zstack_Red_0143
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0143_red/reference_images/reference_images -> /acquisition/Zstack_Red_0143
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0143_red/roi_group_id: dtype=float64 shape=(5,) val="0x280001"
@@ -20670,7 +21163,7 @@ Generating signature for 170714_22_26_27.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0143_red/zoom: dtype=float64 shape=(5,) val="0x697305ec"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0144_green
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0144_green/angle_deg: dtype=float64 shape=(2,) val="0x100001"
 	@description: type=str val="Angle (deg)"
@@ -20692,8 +21185,6 @@ Generating signature for 170714_22_26_27.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0144_green/pixel_mask_index: dtype=int64 shape=(2,) val="0x300004"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0144_green/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0144_green/pixel_time_offsets: dtype=float64 shape=(2, 1) val="0x27df050e"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0144_green/reference_images/Zstack_Red_0144 -> /acquisition/Zstack_Red_0144
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0144_green/reference_images/reference_images -> /acquisition/Zstack_Red_0144
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0144_green/roi_group_id: dtype=float64 shape=(2,) val="0x100001"
@@ -20717,7 +21208,7 @@ Generating signature for 170714_22_26_27.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0144_green/zoom: dtype=float64 shape=(2,) val="0xdc6025f"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0144_red
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0144_red/angle_deg: dtype=float64 shape=(2,) val="0x100001"
 	@description: type=str val="Angle (deg)"
@@ -20739,8 +21230,6 @@ Generating signature for 170714_22_26_27.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0144_red/pixel_mask_index: dtype=int64 shape=(2,) val="0x300004"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0144_red/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0144_red/pixel_time_offsets: dtype=float64 shape=(2, 1) val="0x27df050e"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0144_red/reference_images/Zstack_Red_0144 -> /acquisition/Zstack_Red_0144
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0144_red/reference_images/reference_images -> /acquisition/Zstack_Red_0144
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0144_red/roi_group_id: dtype=float64 shape=(2,) val="0x100001"
@@ -20764,7 +21253,7 @@ Generating signature for 170714_22_26_27.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0144_red/zoom: dtype=float64 shape=(2,) val="0xdc6025f"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0145_green
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0145_green/angle_deg: dtype=float64 shape=(1,) val="[0]"
 	@description: type=str val="Angle (deg)"
@@ -20786,8 +21275,6 @@ Generating signature for 170714_22_26_27.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0145_green/pixel_mask_index: dtype=int64 shape=(1,) val="[1]"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0145_green/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0145_green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x12230407"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0145_green/reference_images/Zstack_Red_0145 -> /acquisition/Zstack_Red_0145
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0145_green/reference_images/reference_images -> /acquisition/Zstack_Red_0145
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0145_green/roi_group_id: dtype=float64 shape=(1,) val="[0]"
@@ -20811,7 +21298,7 @@ Generating signature for 170714_22_26_27.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0145_green/zoom: dtype=float64 shape=(1,) val="[1]"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0145_red
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0145_red/angle_deg: dtype=float64 shape=(1,) val="[0]"
 	@description: type=str val="Angle (deg)"
@@ -20833,8 +21320,6 @@ Generating signature for 170714_22_26_27.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0145_red/pixel_mask_index: dtype=int64 shape=(1,) val="[1]"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0145_red/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0145_red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0x12230407"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0145_red/reference_images/Zstack_Red_0145 -> /acquisition/Zstack_Red_0145
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0145_red/reference_images/reference_images -> /acquisition/Zstack_Red_0145
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0145_red/roi_group_id: dtype=float64 shape=(1,) val="[0]"
@@ -20858,7 +21343,7 @@ Generating signature for 170714_22_26_27.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0145_red/zoom: dtype=float64 shape=(1,) val="[1]"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0146_green
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0146_green/angle_deg: dtype=float64 shape=(3,) val="0x180001"
 	@description: type=str val="Angle (deg)"
@@ -20880,8 +21365,6 @@ Generating signature for 170714_22_26_27.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0146_green/pixel_mask_index: dtype=int64 shape=(3,) val="0x680007"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0146_green/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0146_green/pixel_time_offsets: dtype=float64 shape=(3, 1) val="0x87690b21"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0146_green/reference_images/Zstack_Red_0146 -> /acquisition/Zstack_Red_0146
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0146_green/reference_images/reference_images -> /acquisition/Zstack_Red_0146
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0146_green/roi_group_id: dtype=float64 shape=(3,) val="0x180001"
@@ -20905,7 +21388,7 @@ Generating signature for 170714_22_26_27.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0146_green/zoom: dtype=float64 shape=(3,) val="0x22dd038e"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0146_red
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0146_red/angle_deg: dtype=float64 shape=(3,) val="0x180001"
 	@description: type=str val="Angle (deg)"
@@ -20927,8 +21410,6 @@ Generating signature for 170714_22_26_27.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0146_red/pixel_mask_index: dtype=int64 shape=(3,) val="0x680007"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0146_red/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0146_red/pixel_time_offsets: dtype=float64 shape=(3, 1) val="0x87690b21"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0146_red/reference_images/Zstack_Red_0146 -> /acquisition/Zstack_Red_0146
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0146_red/reference_images/reference_images -> /acquisition/Zstack_Red_0146
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0146_red/roi_group_id: dtype=float64 shape=(3,) val="0x180001"
@@ -20952,7 +21433,7 @@ Generating signature for 170714_22_26_27.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0146_red/zoom: dtype=float64 shape=(3,) val="0x22dd038e"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0147_green
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0147_green/angle_deg: dtype=float64 shape=(7,) val="0x380001"
 	@description: type=str val="Angle (deg)"
@@ -20974,8 +21455,6 @@ Generating signature for 170714_22_26_27.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0147_green/pixel_mask_index: dtype=int64 shape=(7,) val="0x2d8001d"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0147_green/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0147_green/pixel_time_offsets: dtype=float64 shape=(7, 1) val="0x59c519ca"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0147_green/reference_images/Zstack_Red_0147 -> /acquisition/Zstack_Red_0147
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0147_green/reference_images/reference_images -> /acquisition/Zstack_Red_0147
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0147_green/roi_group_id: dtype=float64 shape=(7,) val="0x380001"
@@ -20999,7 +21478,7 @@ Generating signature for 170714_22_26_27.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0147_green/zoom: dtype=float64 shape=(7,) val="0xd5e9084a"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0147_red
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0147_red/angle_deg: dtype=float64 shape=(7,) val="0x380001"
 	@description: type=str val="Angle (deg)"
@@ -21021,8 +21500,6 @@ Generating signature for 170714_22_26_27.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0147_red/pixel_mask_index: dtype=int64 shape=(7,) val="0x2d8001d"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0147_red/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0147_red/pixel_time_offsets: dtype=float64 shape=(7, 1) val="0x59c519ca"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0147_red/reference_images/Zstack_Red_0147 -> /acquisition/Zstack_Red_0147
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0147_red/reference_images/reference_images -> /acquisition/Zstack_Red_0147
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0147_red/roi_group_id: dtype=float64 shape=(7,) val="0x380001"
@@ -21046,7 +21523,7 @@ Generating signature for 170714_22_26_27.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0147_red/zoom: dtype=float64 shape=(7,) val="0xd5e9084a"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0148_green
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0148_green/angle_deg: dtype=float64 shape=(10,) val="0x500001"
 	@description: type=str val="Angle (deg)"
@@ -21068,8 +21545,6 @@ Generating signature for 170714_22_26_27.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0148_green/pixel_mask_index: dtype=int64 shape=(10,) val="0x7300038"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0148_green/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0148_green/pixel_time_offsets: dtype=float64 shape=(10, 1) val="0x3b18268a"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0148_green/reference_images/Zstack_Red_0148 -> /acquisition/Zstack_Red_0148
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0148_green/reference_images/reference_images -> /acquisition/Zstack_Red_0148
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0148_green/roi_group_id: dtype=float64 shape=(10,) val="0x500001"
@@ -21093,7 +21568,7 @@ Generating signature for 170714_22_26_27.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0148_green/zoom: dtype=float64 shape=(10,) val="0xbfad0bd7"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0148_red
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0148_red/angle_deg: dtype=float64 shape=(10,) val="0x500001"
 	@description: type=str val="Angle (deg)"
@@ -21115,8 +21590,6 @@ Generating signature for 170714_22_26_27.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0148_red/pixel_mask_index: dtype=int64 shape=(10,) val="0x7300038"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0148_red/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0148_red/pixel_time_offsets: dtype=float64 shape=(10, 1) val="0x3b18268a"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0148_red/reference_images/Zstack_Red_0148 -> /acquisition/Zstack_Red_0148
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0148_red/reference_images/reference_images -> /acquisition/Zstack_Red_0148
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0148_red/roi_group_id: dtype=float64 shape=(10,) val="0x500001"
@@ -21140,7 +21613,7 @@ Generating signature for 170714_22_26_27.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0148_red/zoom: dtype=float64 shape=(10,) val="0xbfad0bd7"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0149_green
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0149_green/angle_deg: dtype=float64 shape=(12,) val="0x600001"
 	@description: type=str val="Angle (deg)"
@@ -21162,8 +21635,6 @@ Generating signature for 170714_22_26_27.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0149_green/pixel_mask_index: dtype=int64 shape=(12,) val="0xbc0004f"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0149_green/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0149_green/pixel_time_offsets: dtype=float64 shape=(12, 1) val="0x20452cdb"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0149_green/reference_images/Zstack_Red_0149 -> /acquisition/Zstack_Red_0149
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0149_green/reference_images/reference_images -> /acquisition/Zstack_Red_0149
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0149_green/roi_group_id: dtype=float64 shape=(12,) val="0x600001"
@@ -21187,7 +21658,7 @@ Generating signature for 170714_22_26_27.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0149_green/zoom: dtype=float64 shape=(12,) val="0x8ae20e35"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0149_red
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0149_red/angle_deg: dtype=float64 shape=(12,) val="0x600001"
 	@description: type=str val="Angle (deg)"
@@ -21209,8 +21680,6 @@ Generating signature for 170714_22_26_27.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0149_red/pixel_mask_index: dtype=int64 shape=(12,) val="0xbc0004f"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0149_red/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0149_red/pixel_time_offsets: dtype=float64 shape=(12, 1) val="0x20452cdb"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0149_red/reference_images/Zstack_Red_0149 -> /acquisition/Zstack_Red_0149
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0149_red/reference_images/reference_images -> /acquisition/Zstack_Red_0149
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0149_red/roi_group_id: dtype=float64 shape=(12,) val="0x600001"
@@ -21234,7 +21703,7 @@ Generating signature for 170714_22_26_27.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0149_red/zoom: dtype=float64 shape=(12,) val="0x8ae20e35"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0150_green
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0150_green/angle_deg: dtype=float64 shape=(5,) val="0x280001"
 	@description: type=str val="Angle (deg)"
@@ -21256,8 +21725,6 @@ Generating signature for 170714_22_26_27.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0150_green/pixel_mask_index: dtype=int64 shape=(5,) val="0x1400010"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0150_green/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0150_green/pixel_time_offsets: dtype=float64 shape=(5, 1) val="0x224b0f5b"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0150_green/reference_images/Zstack_Red_0150 -> /acquisition/Zstack_Red_0150
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0150_green/reference_images/reference_images -> /acquisition/Zstack_Red_0150
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0150_green/roi_group_id: dtype=float64 shape=(5,) val="0x280001"
@@ -21281,7 +21748,7 @@ Generating signature for 170714_22_26_27.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0150_green/zoom: dtype=float64 shape=(5,) val="0x697305ec"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0150_red
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0150_red/angle_deg: dtype=float64 shape=(5,) val="0x280001"
 	@description: type=str val="Angle (deg)"
@@ -21303,8 +21770,6 @@ Generating signature for 170714_22_26_27.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0150_red/pixel_mask_index: dtype=int64 shape=(5,) val="0x1400010"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0150_red/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0150_red/pixel_time_offsets: dtype=float64 shape=(5, 1) val="0x224b0f5b"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0150_red/reference_images/Zstack_Red_0150 -> /acquisition/Zstack_Red_0150
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0150_red/reference_images/reference_images -> /acquisition/Zstack_Red_0150
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0150_red/roi_group_id: dtype=float64 shape=(5,) val="0x280001"
@@ -21328,7 +21793,7 @@ Generating signature for 170714_22_26_27.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0150_red/zoom: dtype=float64 shape=(5,) val="0x697305ec"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0151_green
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0151_green/angle_deg: dtype=float64 shape=(7,) val="0x380001"
 	@description: type=str val="Angle (deg)"
@@ -21350,8 +21815,6 @@ Generating signature for 170714_22_26_27.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0151_green/pixel_mask_index: dtype=int64 shape=(7,) val="0x2d8001d"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0151_green/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0151_green/pixel_time_offsets: dtype=float64 shape=(7, 1) val="0x37a61b3b"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0151_green/reference_images/Zstack_Red_0151 -> /acquisition/Zstack_Red_0151
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0151_green/reference_images/reference_images -> /acquisition/Zstack_Red_0151
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0151_green/roi_group_id: dtype=float64 shape=(7,) val="0x380001"
@@ -21375,7 +21838,7 @@ Generating signature for 170714_22_26_27.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0151_green/zoom: dtype=float64 shape=(7,) val="0xd5e9084a"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0151_red
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0151_red/angle_deg: dtype=float64 shape=(7,) val="0x380001"
 	@description: type=str val="Angle (deg)"
@@ -21397,8 +21860,6 @@ Generating signature for 170714_22_26_27.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0151_red/pixel_mask_index: dtype=int64 shape=(7,) val="0x2d8001d"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0151_red/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0151_red/pixel_time_offsets: dtype=float64 shape=(7, 1) val="0x37a61b3b"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0151_red/reference_images/Zstack_Red_0151 -> /acquisition/Zstack_Red_0151
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0151_red/reference_images/reference_images -> /acquisition/Zstack_Red_0151
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0151_red/roi_group_id: dtype=float64 shape=(7,) val="0x380001"
@@ -21422,7 +21883,7 @@ Generating signature for 170714_22_26_27.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0151_red/zoom: dtype=float64 shape=(7,) val="0xd5e9084a"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0152_green
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0152_green/angle_deg: dtype=float64 shape=(12,) val="0x600001"
 	@description: type=str val="Angle (deg)"
@@ -21444,8 +21905,6 @@ Generating signature for 170714_22_26_27.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0152_green/pixel_mask_index: dtype=int64 shape=(12,) val="0xbc0004f"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0152_green/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0152_green/pixel_time_offsets: dtype=float64 shape=(12, 1) val="0xfdef3059"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0152_green/reference_images/Zstack_Red_0152 -> /acquisition/Zstack_Red_0152
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0152_green/reference_images/reference_images -> /acquisition/Zstack_Red_0152
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0152_green/roi_group_id: dtype=float64 shape=(12,) val="0x600001"
@@ -21469,7 +21928,7 @@ Generating signature for 170714_22_26_27.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0152_green/zoom: dtype=float64 shape=(12,) val="0x8ae20e35"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0152_red
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0152_red/angle_deg: dtype=float64 shape=(12,) val="0x600001"
 	@description: type=str val="Angle (deg)"
@@ -21491,8 +21950,6 @@ Generating signature for 170714_22_26_27.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0152_red/pixel_mask_index: dtype=int64 shape=(12,) val="0xbc0004f"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0152_red/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0152_red/pixel_time_offsets: dtype=float64 shape=(12, 1) val="0xfdef3059"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0152_red/reference_images/Zstack_Red_0152 -> /acquisition/Zstack_Red_0152
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0152_red/reference_images/reference_images -> /acquisition/Zstack_Red_0152
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0152_red/roi_group_id: dtype=float64 shape=(12,) val="0x600001"
@@ -21516,7 +21973,7 @@ Generating signature for 170714_22_26_27.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0152_red/zoom: dtype=float64 shape=(12,) val="0x8ae20e35"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0153_green
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0153_green/angle_deg: dtype=float64 shape=(13,) val="0x680001"
 	@description: type=str val="Angle (deg)"
@@ -21538,8 +21995,6 @@ Generating signature for 170714_22_26_27.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0153_green/pixel_mask_index: dtype=int64 shape=(13,) val="0xea0005c"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0153_green/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0153_green/pixel_time_offsets: dtype=float64 shape=(13, 1) val="0x6a012f60"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0153_green/reference_images/Zstack_Red_0153 -> /acquisition/Zstack_Red_0153
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0153_green/reference_images/reference_images -> /acquisition/Zstack_Red_0153
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0153_green/roi_group_id: dtype=float64 shape=(13,) val="0x680001"
@@ -21563,7 +22018,7 @@ Generating signature for 170714_22_26_27.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0153_green/zoom: dtype=float64 shape=(13,) val="0xfea90f64"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0153_red
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0153_red/angle_deg: dtype=float64 shape=(13,) val="0x680001"
 	@description: type=str val="Angle (deg)"
@@ -21585,8 +22040,6 @@ Generating signature for 170714_22_26_27.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0153_red/pixel_mask_index: dtype=int64 shape=(13,) val="0xea0005c"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0153_red/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0153_red/pixel_time_offsets: dtype=float64 shape=(13, 1) val="0x6a012f60"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0153_red/reference_images/Zstack_Red_0153 -> /acquisition/Zstack_Red_0153
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0153_red/reference_images/reference_images -> /acquisition/Zstack_Red_0153
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0153_red/roi_group_id: dtype=float64 shape=(13,) val="0x680001"
@@ -21610,7 +22063,7 @@ Generating signature for 170714_22_26_27.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0153_red/zoom: dtype=float64 shape=(13,) val="0xfea90f64"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0154_green
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0154_green/angle_deg: dtype=float64 shape=(6,) val="0x300001"
 	@description: type=str val="Angle (deg)"
@@ -21632,8 +22085,6 @@ Generating signature for 170714_22_26_27.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0154_green/pixel_mask_index: dtype=int64 shape=(6,) val="0x1f00016"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0154_green/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0154_green/pixel_time_offsets: dtype=float64 shape=(6, 1) val="0xbaa314ae"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0154_green/reference_images/Zstack_Red_0154 -> /acquisition/Zstack_Red_0154
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0154_green/reference_images/reference_images -> /acquisition/Zstack_Red_0154
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0154_green/roi_group_id: dtype=float64 shape=(6,) val="0x300001"
@@ -21657,7 +22108,7 @@ Generating signature for 170714_22_26_27.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0154_green/zoom: dtype=float64 shape=(6,) val="0x9af2071b"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0154_red
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0154_red/angle_deg: dtype=float64 shape=(6,) val="0x300001"
 	@description: type=str val="Angle (deg)"
@@ -21679,8 +22130,6 @@ Generating signature for 170714_22_26_27.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0154_red/pixel_mask_index: dtype=int64 shape=(6,) val="0x1f00016"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0154_red/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0154_red/pixel_time_offsets: dtype=float64 shape=(6, 1) val="0xbaa314ae"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0154_red/reference_images/Zstack_Red_0154 -> /acquisition/Zstack_Red_0154
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0154_red/reference_images/reference_images -> /acquisition/Zstack_Red_0154
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0154_red/roi_group_id: dtype=float64 shape=(6,) val="0x300001"
@@ -21704,7 +22153,7 @@ Generating signature for 170714_22_26_27.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0154_red/zoom: dtype=float64 shape=(6,) val="0x9af2071b"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0163_green
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0163_green/angle_deg: dtype=float64 shape=(3,) val="0x180001"
 	@description: type=str val="Angle (deg)"
@@ -21726,8 +22175,6 @@ Generating signature for 170714_22_26_27.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0163_green/pixel_mask_index: dtype=int64 shape=(3,) val="0x680007"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0163_green/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0163_green/pixel_time_offsets: dtype=float64 shape=(3, 1) val="0x964f0a85"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0163_green/reference_images/Zstack_Red_0163 -> /acquisition/Zstack_Red_0163
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0163_green/reference_images/reference_images -> /acquisition/Zstack_Red_0163
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0163_green/roi_group_id: dtype=float64 shape=(3,) val="0x180001"
@@ -21751,7 +22198,7 @@ Generating signature for 170714_22_26_27.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0163_green/zoom: dtype=float64 shape=(3,) val="0x22dd038e"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0163_red
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0163_red/angle_deg: dtype=float64 shape=(3,) val="0x180001"
 	@description: type=str val="Angle (deg)"
@@ -21773,8 +22220,6 @@ Generating signature for 170714_22_26_27.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0163_red/pixel_mask_index: dtype=int64 shape=(3,) val="0x680007"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0163_red/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0163_red/pixel_time_offsets: dtype=float64 shape=(3, 1) val="0x964f0a85"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0163_red/reference_images/Zstack_Red_0163 -> /acquisition/Zstack_Red_0163
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0163_red/reference_images/reference_images -> /acquisition/Zstack_Red_0163
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0163_red/roi_group_id: dtype=float64 shape=(3,) val="0x180001"
@@ -21798,7 +22243,7 @@ Generating signature for 170714_22_26_27.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0163_red/zoom: dtype=float64 shape=(3,) val="0x22dd038e"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0165_green
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0165_green/angle_deg: dtype=float64 shape=(1,) val="[0]"
 	@description: type=str val="Angle (deg)"
@@ -21820,8 +22265,6 @@ Generating signature for 170714_22_26_27.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0165_green/pixel_mask_index: dtype=int64 shape=(1,) val="[1]"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0165_green/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0165_green/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xfaf0341"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0165_green/reference_images/Zstack_Red_0165 -> /acquisition/Zstack_Red_0165
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0165_green/reference_images/reference_images -> /acquisition/Zstack_Red_0165
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0165_green/roi_group_id: dtype=float64 shape=(1,) val="[0]"
@@ -21845,7 +22288,7 @@ Generating signature for 170714_22_26_27.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0165_green/zoom: dtype=float64 shape=(1,) val="[1]"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0165_red
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0165_red/angle_deg: dtype=float64 shape=(1,) val="[0]"
 	@description: type=str val="Angle (deg)"
@@ -21867,8 +22310,6 @@ Generating signature for 170714_22_26_27.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0165_red/pixel_mask_index: dtype=int64 shape=(1,) val="[1]"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0165_red/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0165_red/pixel_time_offsets: dtype=float64 shape=(1, 1) val="0xfaf0341"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0165_red/reference_images/Zstack_Red_0165 -> /acquisition/Zstack_Red_0165
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0165_red/reference_images/reference_images -> /acquisition/Zstack_Red_0165
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0165_red/roi_group_id: dtype=float64 shape=(1,) val="[0]"
@@ -21892,7 +22333,7 @@ Generating signature for 170714_22_26_27.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0165_red/zoom: dtype=float64 shape=(1,) val="[1]"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0167_green
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0167_green/angle_deg: dtype=float64 shape=(2,) val="0x100001"
 	@description: type=str val="Angle (deg)"
@@ -21914,8 +22355,6 @@ Generating signature for 170714_22_26_27.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0167_green/pixel_mask_index: dtype=int64 shape=(2,) val="0x300004"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0167_green/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0167_green/pixel_time_offsets: dtype=float64 shape=(2, 1) val="0x33a005c6"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0167_green/reference_images/Zstack_Red_0167 -> /acquisition/Zstack_Red_0167
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0167_green/reference_images/reference_images -> /acquisition/Zstack_Red_0167
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0167_green/roi_group_id: dtype=float64 shape=(2,) val="0x100001"
@@ -21939,7 +22378,7 @@ Generating signature for 170714_22_26_27.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0167_green/zoom: dtype=float64 shape=(2,) val="0xdc6025f"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0167_red
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0167_red/angle_deg: dtype=float64 shape=(2,) val="0x100001"
 	@description: type=str val="Angle (deg)"
@@ -21961,8 +22400,6 @@ Generating signature for 170714_22_26_27.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0167_red/pixel_mask_index: dtype=int64 shape=(2,) val="0x300004"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0167_red/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0167_red/pixel_time_offsets: dtype=float64 shape=(2, 1) val="0x33a005c6"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0167_red/reference_images/Zstack_Red_0167 -> /acquisition/Zstack_Red_0167
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0167_red/reference_images/reference_images -> /acquisition/Zstack_Red_0167
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0167_red/roi_group_id: dtype=float64 shape=(2,) val="0x100001"
@@ -21986,7 +22423,7 @@ Generating signature for 170714_22_26_27.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0167_red/zoom: dtype=float64 shape=(2,) val="0xdc6025f"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0168_green
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0168_green/angle_deg: dtype=float64 shape=(17,) val="0x880001"
 	@description: type=str val="Angle (deg)"
@@ -22008,8 +22445,6 @@ Generating signature for 170714_22_26_27.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0168_green/pixel_mask_index: dtype=int64 shape=(17,) val="0x1ed0009a"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0168_green/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0168_green/pixel_time_offsets: dtype=float64 shape=(17, 1) val="0x20f1428b"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0168_green/reference_images/Zstack_Red_0168 -> /acquisition/Zstack_Red_0168
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0168_green/reference_images/reference_images -> /acquisition/Zstack_Red_0168
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0168_green/roi_group_id: dtype=float64 shape=(17,) val="0x880001"
@@ -22033,7 +22468,7 @@ Generating signature for 170714_22_26_27.nwb
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0168_green/zoom: dtype=float64 shape=(17,) val="0x2ca21420"
 	@description: type=str val="Zoom"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0168_red
-	@colnames: dtype=object shape=(19,) val="0xaa674967"
+	@colnames: dtype=object shape=(18,) val="0x8baf41de"
 	@description: type=str val="Reference Z stack"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0168_red/angle_deg: dtype=float64 shape=(17,) val="0x880001"
 	@description: type=str val="Angle (deg)"
@@ -22055,8 +22490,6 @@ Generating signature for 170714_22_26_27.nwb
 	@description: type=str val="Pixel masks for each ROI"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0168_red/pixel_mask_index: dtype=int64 shape=(17,) val="0x1ed0009a"
 	@target: type=Reference val="->/processing/Acquired_ROIs/ImageSegmentation/Zstack0168_red/pixel_mask"
-/processing/Acquired_ROIs/ImageSegmentation/Zstack0168_red/pixel_time_offsets: dtype=float64 shape=(17, 1) val="0x20f1428b"
-	@description: type=str val="Time offsets for each pixel"
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0168_red/reference_images/Zstack_Red_0168 -> /acquisition/Zstack_Red_0168
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0168_red/reference_images/reference_images -> /acquisition/Zstack_Red_0168
 /processing/Acquired_ROIs/ImageSegmentation/Zstack0168_red/roi_group_id: dtype=float64 shape=(17,) val="0x880001"
@@ -22081,9 +22514,10 @@ Generating signature for 170714_22_26_27.nwb
 	@description: type=str val="Zoom"
 /session_description: dtype=object shape=() val="One or two sentences descri...0x65b618d5"
 /session_start_time: dtype=object shape=() val="2017-07-14T22:30:15.125589+...0x6b110678"
-/specifications/silverlab_extended_schema/0.2/namespace: dtype=object shape=() val="{"namespaces":[{"doc":"Exte...0x5f6a6a92"
-/specifications/silverlab_extended_schema/0.2/silverlab.metadata: dtype=object shape=() val="{"groups":[{"doc":"A place ...0xc0d670ae"
-/specifications/silverlab_extended_schema/0.2/silverlab.ophys: dtype=object shape=() val="{"groups":[{"datasets":[{"s...0xeab28ad7"
+/specifications/silverlab_extended_schema/0.3/namespace: dtype=object shape=() val="{"namespaces":[{"doc":"Exte...0x2db67446"
+/specifications/silverlab_extended_schema/0.3/silverlab.metadata: dtype=object shape=() val="{"groups":[{"doc":"A place ...0x908295e2"
+/specifications/silverlab_extended_schema/0.3/silverlab.ophys: dtype=object shape=() val="{"groups":[{"datasets":[{"s...0xeab28ad7"
+/specifications/silverlab_extended_schema/0.3/silverlab.roi: dtype=object shape=() val="{"groups":[{"datasets":[{"s...0x5c700123"
 /stimulus/presentation/air_puff
 	@comments: type=str val="Delivered 'instantaneously' at the specified times"
 	@description: type=str val="Air puff stimulus"

--- a/tests/data/metadata_only_B.sig2
+++ b/tests/data/metadata_only_B.sig2
@@ -22,7 +22,7 @@ Generating signature for metadata_only_B.nwb
 /session_description: dtype=object shape=() val="B's session description."
 /session_start_time: dtype=object shape=() val="2020-05-10T00:00:00+01:00"
 /specifications/silverlab_extended_schema/0.3/namespace: dtype=object shape=() val="{"namespaces":[{"doc":"Exte...0x2db67446"
-/specifications/silverlab_extended_schema/0.3/silverlab.metadata: dtype=object shape=() val="{"groups":[{"doc":"A place ...0xc0d670ae"
+/specifications/silverlab_extended_schema/0.3/silverlab.metadata: dtype=object shape=() val="{"groups":[{"doc":"A place ...0x908295e2"
 /specifications/silverlab_extended_schema/0.3/silverlab.ophys: dtype=object shape=() val="{"groups":[{"datasets":[{"s...0xeab28ad7"
 /specifications/silverlab_extended_schema/0.3/silverlab.roi: dtype=object shape=() val="{"groups":[{"datasets":[{"s...0x5c700123"
 /timestamps_reference_time: dtype=object shape=() val="2020-05-10T00:00:00+01:00"

--- a/tests/data/metadata_only_B.sig2
+++ b/tests/data/metadata_only_B.sig2
@@ -21,8 +21,4 @@ Generating signature for metadata_only_B.nwb
 /identifier: dtype=ignored shape=ignored val="ignored"
 /session_description: dtype=object shape=() val="B's session description."
 /session_start_time: dtype=object shape=() val="2020-05-10T00:00:00+01:00"
-/specifications/silverlab_extended_schema/0.3/namespace: dtype=object shape=() val="{"namespaces":[{"doc":"Exte...0x2db67446"
-/specifications/silverlab_extended_schema/0.3/silverlab.metadata: dtype=object shape=() val="{"groups":[{"doc":"A place ...0x908295e2"
-/specifications/silverlab_extended_schema/0.3/silverlab.ophys: dtype=object shape=() val="{"groups":[{"datasets":[{"s...0xeab28ad7"
-/specifications/silverlab_extended_schema/0.3/silverlab.roi: dtype=object shape=() val="{"groups":[{"datasets":[{"s...0x5c700123"
 /timestamps_reference_time: dtype=object shape=() val="2020-05-10T00:00:00+01:00"

--- a/tests/data/sample_miniscan_fred_170322_14_06_43.sig2
+++ b/tests/data/sample_miniscan_fred_170322_14_06_43.sig2
@@ -2086,10 +2086,6 @@ Generating signature for sample_miniscan_fred_170322_14_06_43.nwb
 	@description: type=str val="Zoom"
 /session_description: dtype=object shape=() val="One or two sentences descri...0x65b618d5"
 /session_start_time: dtype=object shape=() val="2017-03-22T14:09:33.537754+...0x6b2d067a"
-/specifications/silverlab_extended_schema/0.3/namespace: dtype=object shape=() val="{"namespaces":[{"doc":"Exte...0x2db67446"
-/specifications/silverlab_extended_schema/0.3/silverlab.metadata: dtype=object shape=() val="{"groups":[{"doc":"A place ...0x908295e2"
-/specifications/silverlab_extended_schema/0.3/silverlab.ophys: dtype=object shape=() val="{"groups":[{"datasets":[{"s...0xeab28ad7"
-/specifications/silverlab_extended_schema/0.3/silverlab.roi: dtype=object shape=() val="{"groups":[{"datasets":[{"s...0x5c700123"
 /stimulus/presentation/air_puff
 	@comments: type=str val="Delivered 'instantaneously' at the specified times"
 	@description: type=str val="Air puff stimulus"

--- a/tests/data/sample_miniscan_fred_170322_14_06_43.sig2
+++ b/tests/data/sample_miniscan_fred_170322_14_06_43.sig2
@@ -1960,6 +1960,7 @@ Generating signature for sample_miniscan_fred_170322_14_06_43.nwb
 /general/optophysiology/Zstack0078_red/reference_frame: dtype=object shape=() val="TODO: In lab book (partly?)"
 /general/session_id: dtype=object shape=() val="sample_miniscan_fred_170322...0xfadc0c11"
 /general/silverlab_metadata
+	@labview_version: type=str val="pre-2018 (original)"
 	@silverlab_api_version: type=str val="0.2"
 /general/silverlab_optophysiology
 	@cycle_time: dtype=float64 shape=() val="0.033304"
@@ -2086,7 +2087,7 @@ Generating signature for sample_miniscan_fred_170322_14_06_43.nwb
 /session_description: dtype=object shape=() val="One or two sentences descri...0x65b618d5"
 /session_start_time: dtype=object shape=() val="2017-03-22T14:09:33.537754+...0x6b2d067a"
 /specifications/silverlab_extended_schema/0.3/namespace: dtype=object shape=() val="{"namespaces":[{"doc":"Exte...0x2db67446"
-/specifications/silverlab_extended_schema/0.3/silverlab.metadata: dtype=object shape=() val="{"groups":[{"doc":"A place ...0xc0d670ae"
+/specifications/silverlab_extended_schema/0.3/silverlab.metadata: dtype=object shape=() val="{"groups":[{"doc":"A place ...0x908295e2"
 /specifications/silverlab_extended_schema/0.3/silverlab.ophys: dtype=object shape=() val="{"groups":[{"datasets":[{"s...0xeab28ad7"
 /specifications/silverlab_extended_schema/0.3/silverlab.roi: dtype=object shape=() val="{"groups":[{"datasets":[{"s...0x5c700123"
 /stimulus/presentation/air_puff

--- a/tests/data/sample_pointing_fred_170317_10_11_01.sig2
+++ b/tests/data/sample_pointing_fred_170317_10_11_01.sig2
@@ -2398,10 +2398,6 @@ Generating signature for sample_pointing_fred_170317_10_11_01.nwb
 	@description: type=str val="Zoom"
 /session_description: dtype=object shape=() val="One or two sentences descri...0x65b618d5"
 /session_start_time: dtype=object shape=() val="2017-03-17T10:17:33.899507+...0x6b7d0680"
-/specifications/silverlab_extended_schema/0.3/namespace: dtype=object shape=() val="{"namespaces":[{"doc":"Exte...0x2db67446"
-/specifications/silverlab_extended_schema/0.3/silverlab.metadata: dtype=object shape=() val="{"groups":[{"doc":"A place ...0x908295e2"
-/specifications/silverlab_extended_schema/0.3/silverlab.ophys: dtype=object shape=() val="{"groups":[{"datasets":[{"s...0xeab28ad7"
-/specifications/silverlab_extended_schema/0.3/silverlab.roi: dtype=object shape=() val="{"groups":[{"datasets":[{"s...0x5c700123"
 /stimulus/presentation/air_puff
 	@comments: type=str val="Delivered 'instantaneously' at the specified times"
 	@description: type=str val="Air puff stimulus"

--- a/tests/data/sample_pointing_fred_170317_10_11_01.sig2
+++ b/tests/data/sample_pointing_fred_170317_10_11_01.sig2
@@ -2272,6 +2272,7 @@ Generating signature for sample_pointing_fred_170317_10_11_01.nwb
 /general/optophysiology/Zstack0079_red/reference_frame: dtype=object shape=() val="TODO: In lab book (partly?)"
 /general/session_id: dtype=object shape=() val="sample_pointing_fred_170317...0xfd020c1d"
 /general/silverlab_metadata
+	@labview_version: type=str val="pre-2018 (original)"
 	@silverlab_api_version: type=str val="0.2"
 /general/silverlab_optophysiology
 	@cycle_time: dtype=float64 shape=() val="0.0046993"
@@ -2398,7 +2399,7 @@ Generating signature for sample_pointing_fred_170317_10_11_01.nwb
 /session_description: dtype=object shape=() val="One or two sentences descri...0x65b618d5"
 /session_start_time: dtype=object shape=() val="2017-03-17T10:17:33.899507+...0x6b7d0680"
 /specifications/silverlab_extended_schema/0.3/namespace: dtype=object shape=() val="{"namespaces":[{"doc":"Exte...0x2db67446"
-/specifications/silverlab_extended_schema/0.3/silverlab.metadata: dtype=object shape=() val="{"groups":[{"doc":"A place ...0xc0d670ae"
+/specifications/silverlab_extended_schema/0.3/silverlab.metadata: dtype=object shape=() val="{"groups":[{"doc":"A place ...0x908295e2"
 /specifications/silverlab_extended_schema/0.3/silverlab.ophys: dtype=object shape=() val="{"groups":[{"datasets":[{"s...0xeab28ad7"
 /specifications/silverlab_extended_schema/0.3/silverlab.roi: dtype=object shape=() val="{"groups":[{"datasets":[{"s...0x5c700123"
 /stimulus/presentation/air_puff

--- a/tests/data/sample_pointing_videos_161215_15_34_21.sig2
+++ b/tests/data/sample_pointing_videos_161215_15_34_21.sig2
@@ -1936,10 +1936,6 @@ Generating signature for sample_pointing_videos_161215_15_34_21.nwb
 	@description: type=str val="Zoom"
 /session_description: dtype=object shape=() val="One or two sentences descri...0x65b618d5"
 /session_start_time: dtype=object shape=() val="2016-12-15T15:23:11.436200+...0x6a4f0664"
-/specifications/silverlab_extended_schema/0.3/namespace: dtype=object shape=() val="{"namespaces":[{"doc":"Exte...0x2db67446"
-/specifications/silverlab_extended_schema/0.3/silverlab.metadata: dtype=object shape=() val="{"groups":[{"doc":"A place ...0x908295e2"
-/specifications/silverlab_extended_schema/0.3/silverlab.ophys: dtype=object shape=() val="{"groups":[{"datasets":[{"s...0xeab28ad7"
-/specifications/silverlab_extended_schema/0.3/silverlab.roi: dtype=object shape=() val="{"groups":[{"datasets":[{"s...0x5c700123"
 /stimulus/presentation/air_puff
 	@comments: type=str val="Delivered 'instantaneously' at the specified times"
 	@description: type=str val="Air puff stimulus"

--- a/tests/data/sample_pointing_videos_161215_15_34_21.sig2
+++ b/tests/data/sample_pointing_videos_161215_15_34_21.sig2
@@ -1630,6 +1630,7 @@ Generating signature for sample_pointing_videos_161215_15_34_21.nwb
 /general/optophysiology/Zstack0049_red/reference_frame: dtype=object shape=() val="TODO: In lab book (partly?)"
 /general/session_id: dtype=object shape=() val="sample_pointing_videos_1612...0x1dd40d0f"
 /general/silverlab_metadata
+	@labview_version: type=str val="pre-2018 (original)"
 	@silverlab_api_version: type=str val="0.2"
 /general/silverlab_optophysiology
 	@cycle_time: dtype=float64 shape=() val="0.00286745"
@@ -1936,7 +1937,7 @@ Generating signature for sample_pointing_videos_161215_15_34_21.nwb
 /session_description: dtype=object shape=() val="One or two sentences descri...0x65b618d5"
 /session_start_time: dtype=object shape=() val="2016-12-15T15:23:11.436200+...0x6a4f0664"
 /specifications/silverlab_extended_schema/0.3/namespace: dtype=object shape=() val="{"namespaces":[{"doc":"Exte...0x2db67446"
-/specifications/silverlab_extended_schema/0.3/silverlab.metadata: dtype=object shape=() val="{"groups":[{"doc":"A place ...0xc0d670ae"
+/specifications/silverlab_extended_schema/0.3/silverlab.metadata: dtype=object shape=() val="{"groups":[{"doc":"A place ...0x908295e2"
 /specifications/silverlab_extended_schema/0.3/silverlab.ophys: dtype=object shape=() val="{"groups":[{"datasets":[{"s...0xeab28ad7"
 /specifications/silverlab_extended_schema/0.3/silverlab.roi: dtype=object shape=() val="{"groups":[{"datasets":[{"s...0x5c700123"
 /stimulus/presentation/air_puff

--- a/tests/data/sample_rois_200206_16_30_32.sig2
+++ b/tests/data/sample_rois_200206_16_30_32.sig2
@@ -2436,6 +2436,7 @@ Generating signature for sample_rois_200206_16_30_32.nwb
 /general/optophysiology/Zstack0090_red/reference_frame: dtype=object shape=() val="TODO: In lab book (partly?)"
 /general/session_id: dtype=object shape=() val="sample_rois_200206_16_30_32"
 /general/silverlab_metadata
+	@labview_version: type=str val="2.3.1"
 	@silverlab_api_version: type=str val="0.2"
 /general/silverlab_optophysiology
 	@cycle_time: dtype=float64 shape=() val="0.0059246"
@@ -2742,7 +2743,7 @@ Generating signature for sample_rois_200206_16_30_32.nwb
 /session_description: dtype=object shape=() val="One or two sentences descri...0x65b618d5"
 /session_start_time: dtype=object shape=() val="2020-02-06T16:31:09.093605+...0x6a43066d"
 /specifications/silverlab_extended_schema/0.3/namespace: dtype=object shape=() val="{"namespaces":[{"doc":"Exte...0x2db67446"
-/specifications/silverlab_extended_schema/0.3/silverlab.metadata: dtype=object shape=() val="{"groups":[{"doc":"A place ...0xc0d670ae"
+/specifications/silverlab_extended_schema/0.3/silverlab.metadata: dtype=object shape=() val="{"groups":[{"doc":"A place ...0x908295e2"
 /specifications/silverlab_extended_schema/0.3/silverlab.ophys: dtype=object shape=() val="{"groups":[{"datasets":[{"s...0xeab28ad7"
 /specifications/silverlab_extended_schema/0.3/silverlab.roi: dtype=object shape=() val="{"groups":[{"datasets":[{"s...0x5c700123"
 /stimulus/presentation/air_puff

--- a/tests/data/sample_rois_200206_16_30_32.sig2
+++ b/tests/data/sample_rois_200206_16_30_32.sig2
@@ -2742,10 +2742,6 @@ Generating signature for sample_rois_200206_16_30_32.nwb
 	@description: type=str val="Zoom"
 /session_description: dtype=object shape=() val="One or two sentences descri...0x65b618d5"
 /session_start_time: dtype=object shape=() val="2020-02-06T16:31:09.093605+...0x6a43066d"
-/specifications/silverlab_extended_schema/0.3/namespace: dtype=object shape=() val="{"namespaces":[{"doc":"Exte...0x2db67446"
-/specifications/silverlab_extended_schema/0.3/silverlab.metadata: dtype=object shape=() val="{"groups":[{"doc":"A place ...0x908295e2"
-/specifications/silverlab_extended_schema/0.3/silverlab.ophys: dtype=object shape=() val="{"groups":[{"datasets":[{"s...0xeab28ad7"
-/specifications/silverlab_extended_schema/0.3/silverlab.roi: dtype=object shape=() val="{"groups":[{"datasets":[{"s...0x5c700123"
 /stimulus/presentation/air_puff
 	@comments: type=str val="Delivered 'instantaneously' at the specified times"
 	@description: type=str val="Air puff stimulus"

--- a/tests/test_labview_import.py
+++ b/tests/test_labview_import.py
@@ -138,11 +138,11 @@ def test_roundtrip(tmpdir, ref_data_dir):
     # find a way to remove them.
     # with pynwb.NWBHDF5IO(nwb_path, 'r', load_namespaces=True) as io:
     #     new_file = io.read()
-    # Right now, just check tha the file has been read without errors
+    # Right now, just check that the file has been read without errors
     # assert isinstance(new_file, pynwb.NWBFile)
 
-    # Since the above isn't meaningful test, roughly check that we have
-    # includeed the extension spec and custom medata in the file.
+    # Since the above isn't a meaningful test, roughly check that we have
+    # included the extension spec and custom medata in the file.
     with h5py.File(nwb_path, 'r') as new_file:
         assert 'silverlab_extended_schema' in new_file['specifications']
         assert 'silverlab_metadata' in new_file['general']

--- a/tests/test_labview_import.py
+++ b/tests/test_labview_import.py
@@ -1,6 +1,7 @@
 
 import os
 
+import h5py
 import pytest
 
 from silverlabnwb import NwbFile
@@ -113,3 +114,36 @@ class TestFullImporting(object):
     def test_fred_patch(self, do_import_test):
         """A sample dataset from Fred with miniscans."""
         do_import_test('170322_14_06_43', True)
+
+
+@pytest.mark.skipif(
+    not os.path.isdir(DATA_PATH),
+    reason="raw data folder '{}' not present".format(DATA_PATH))
+def test_roundtrip(tmpdir, ref_data_dir):
+    """A simple check that file written can be read back in.
+
+    Currently this does not do anything besides ensure there are no failures.
+    Reading could fail, for example, if the extension spec is not included
+    in the NWB file by accident.
+    """
+    # Write one of the subsampled experiments to NWB
+    expt = 'sample_pointing_fred_170317_10_11_01'
+    nwb_path = os.path.join(str(tmpdir), expt + '.nwb')
+    labview_path = os.path.join(DATA_PATH, expt)
+    with NwbFile(nwb_path, mode='w') as nwb:
+        nwb.import_labview_folder(labview_path)
+
+    # You would think the below would be a good check, but actually not.
+    # The extensions are already loaded (from writing the file) and I can't
+    # find a way to remove them.
+    # with pynwb.NWBHDF5IO(nwb_path, 'r', load_namespaces=True) as io:
+    #     new_file = io.read()
+    # Right now, just check tha the file has been read without errors
+    # assert isinstance(new_file, pynwb.NWBFile)
+
+    # Since the above isn't meaningful test, roughly check that we have
+    # includeed the extension spec and custom medata in the file.
+    with h5py.File(nwb_path, 'r') as new_file:
+        assert 'silverlab_extended_schema' in new_file['specifications']
+        assert 'silverlab_metadata' in new_file['general']
+        assert 'silverlab_optophysiology' in new_file['general']


### PR DESCRIPTION
* Add an attribute to  the lab metadata to hold the LabVIEW version (unless creating from metadata only)
* Update large file signatures to also reflect the changes from #58.

The new attribute is optional, but I wonder whether it's best to always have it and set it to "None" or "N/A" if we don't have any LabVIEW data (e.g. if creating a minimal NWB file from metadata only).